### PR TITLE
Explicit conflict marker detection

### DIFF
--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -140,7 +140,7 @@ public class ArgumentProcessor {
         importResult.ifPresent(result -> {
             OutputPrinter printer = new SystemOutputPrinter();
             if (result.hasWarnings()) {
-                printer.showMessage(result.getErrorMessage());
+                printer.showMessage(result.getWarningsAsString());
             }
         });
         return importResult;

--- a/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -189,7 +189,7 @@ public class JabRefGUI {
         for (ParserResult pr : failed) {
             String message = Localization.lang("Error opening file '%0'.",
                     pr.getPath().map(Path::toString).orElse("(File name unknown)")) + "\n" +
-                    pr.getErrorMessage();
+                    pr.getWarningsAsString();
 
             mainFrame.getDialogService().showErrorDialogAndWait(Localization.lang("Error opening file"), message);
         }

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -276,7 +276,7 @@ public class SourceTab extends EntryEditorTab {
             if (parserResult.hasWarnings()) {
                 // put the warning into as exception text -> it will be displayed to the user
 
-                throw new IllegalStateException(parserResult.getErrorMessage());
+                throw new IllegalStateException(parserResult.getWarningsAsString());
             }
 
             NamedCompound compound = new NamedCompound(Localization.lang("source edit"));

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -114,7 +114,7 @@ public class ImportHandler {
                             List<BibEntry> pdfEntriesInFile = pdfImporterResult.getDatabase().getEntries();
 
                             if (pdfImporterResult.hasWarnings()) {
-                                addResultToList(file, false, Localization.lang("Error reading PDF content: %0", pdfImporterResult.getErrorMessage()));
+                                addResultToList(file, false, Localization.lang("Error reading PDF content: %0", pdfImporterResult.getWarningsAsString()));
                             }
 
                             if (!pdfEntriesInFile.isEmpty()) {
@@ -127,7 +127,7 @@ public class ImportHandler {
                         } else if (FileUtil.isBibFile(file)) {
                             var bibtexParserResult = contentImporter.importFromBibFile(file, fileUpdateMonitor);
                             if (bibtexParserResult.hasWarnings()) {
-                                addResultToList(file, false, bibtexParserResult.getErrorMessage());
+                                addResultToList(file, false, bibtexParserResult.getWarningsAsString());
                             }
 
                             entriesToAdd.addAll(bibtexParserResult.getDatabaseContext().getEntries());

--- a/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
@@ -206,7 +206,7 @@ public class OpenDatabaseAction extends SimpleCommand {
                     Globals.getFileUpdateMonitor());
             if (result.hasWarnings()) {
                 String content = Localization.lang("Please check your library file for wrong syntax.")
-                        + "\n\n" + result.getErrorMessage();
+                        + "\n\n" + result.getWarningsAsString();
                 DefaultTaskExecutor.runInJavaFXThread(() ->
                         dialogService.showWarningDialogAndWait(Localization.lang("Open library error"), content));
             }

--- a/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
+++ b/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
@@ -193,7 +193,7 @@ public class ImportFormatReader {
                     parserResult.setPath(filePath);
                     return new UnknownFormatImport(ImportFormatReader.BIBTEX_FORMAT, parserResult);
                 } else {
-                    throw new ImportException(parserResult.getErrorMessage());
+                    throw new ImportException(parserResult.getWarningsAsString());
                 }
             } catch (IOException ignore) {
                 // Ignored

--- a/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -157,6 +157,20 @@ public class ParserResult {
         return changedOnMigration;
     }
 
+    @Override
+    public String toString() {
+        return "ParserResult{" +
+                "entryTypes=" + entryTypes +
+                ", warnings=" + warnings +
+                ", database=" + database +
+                ", metaData=" + metaData +
+                ", file=" + file +
+                ", invalid=" + invalid +
+                ", toOpenTab=" + toOpenTab +
+                ", changedOnMigration=" + changedOnMigration +
+                '}';
+    }
+
     public void setChangedOnMigration(boolean wasChangedOnMigration) {
         this.changedOnMigration = wasChangedOnMigration;
     }

--- a/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -52,7 +52,7 @@ public class ParserResult {
         return parserResult;
     }
 
-    private static String getErrorMessage(Exception exception) {
+    private static String getWarningsAsString(Exception exception) {
         String errorMessage = exception.getLocalizedMessage();
         if (exception.getCause() != null) {
             errorMessage += " Caused by: " + exception.getCause().getLocalizedMessage();
@@ -61,7 +61,7 @@ public class ParserResult {
     }
 
     public static ParserResult fromError(Exception exception) {
-        return fromErrorMessage(getErrorMessage(exception));
+        return fromErrorMessage(getWarningsAsString(exception));
     }
 
     /**
@@ -111,7 +111,7 @@ public class ParserResult {
     }
 
     public void addException(Exception exception) {
-        String errorMessage = getErrorMessage(exception);
+        String errorMessage = getWarningsAsString(exception);
         addWarning(errorMessage);
     }
 
@@ -123,16 +123,16 @@ public class ParserResult {
         return new ArrayList<>(warnings);
     }
 
+    public String getWarningsAsString() {
+        return String.join(" ", warnings());
+    }
+
     public boolean isInvalid() {
         return invalid;
     }
 
     public void setInvalid(boolean invalid) {
         this.invalid = invalid;
-    }
-
-    public String getErrorMessage() {
-        return String.join(" ", warnings());
     }
 
     public BibDatabaseContext getDatabaseContext() {

--- a/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
@@ -173,7 +173,7 @@ public class MedlineFetcher implements IdBasedParserFetcher, SearchBasedFetcher 
             ParserResult result = new MedlineImporter().importDatabase(
                     new BufferedReader(new InputStreamReader(data.getInputStream(), StandardCharsets.UTF_8)));
             if (result.hasWarnings()) {
-                LOGGER.warn(result.getErrorMessage());
+                LOGGER.warn(result.getWarningsAsString());
             }
             List<BibEntry> resultList = result.getDatabase().getEntries();
             resultList.forEach(this::doPostCleanup);

--- a/src/main/java/org/jabref/model/database/BibDatabase.java
+++ b/src/main/java/org/jabref/model/database/BibDatabase.java
@@ -646,4 +646,16 @@ public class BibDatabase {
     public String getNewLineSeparator() {
         return newLineSeparator;
     }
+
+    @Override
+    public String toString() {
+        return "BibDatabase{" +
+                "entries.size()=" + entries.size() +
+                ", bibtexStrings.size()=" + bibtexStrings.size() +
+                ", preamble='" + preamble + '\'' +
+                ", epilog='" + epilog + '\'' +
+                ", sharedDatabaseID='" + sharedDatabaseID + '\'' +
+                ", newLineSeparator='" + newLineSeparator + '\'' +
+                '}';
+    }
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1923,4 +1923,27 @@ class BibtexParserTest {
 
         assertEquals(Optional.of("#apr#"), result.get().getField(StandardField.MONTH));
     }
+
+    @Test
+    void conflictMarkersResultInProperParseError() throws Exception {
+        String input = """
+                @Article{first,
+                    author = {Author},
+                    <<<<<<< HEAD:test.bib
+                    title = {Title},
+                    =======
+                    title = {My title},
+                    >>>>>>> 77976da35a11db4580b80ae27e8d65caf5208086:test.bib
+                }
+
+                @Article{second,
+                  author = {Valid Author},
+                }
+                """;
+        ParserResult parserResult = parser.parse(new StringReader(input));
+
+        ParserResult expected = ParserResult.fromErrorMessage("Found git conflict markers");
+
+        assertEquals(expected, parserResult);
+    }
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/ImporterTestEngine.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/ImporterTestEngine.java
@@ -50,7 +50,7 @@ public class ImporterTestEngine {
     public static void testImportEntries(Importer importer, String fileName, String fileType) throws IOException, ImportException {
         ParserResult parserResult = importer.importDatabase(getPath(fileName));
         if (parserResult.isInvalid()) {
-            throw new ImportException(parserResult.getErrorMessage());
+            throw new ImportException(parserResult.getWarningsAsString());
         }
         List<BibEntry> entries = parserResult.getDatabase()
                                              .getEntries();


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/9167

WIP, because the parsing architecture is a bit complicated here.

We cannot "just" read the whole file, because it could be very slow when reading large data bases.