### PR TITLE
Fix JavaDoc

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,3 +209,15 @@ jobs:
       - uses: actions/checkout@v3
       - name: Merge Conflict finder
         uses: olivernybroe/action-conflict-finder@v4.0
+  javadoc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 20
+          distribution: 'temurin'
+          cache: 'gradle'
+      - run: ./gradlew generateDocs

--- a/build.gradle
+++ b/build.gradle
@@ -386,6 +386,12 @@ javadoc {
     }
 }
 
+task generateDocs(type: Javadoc) {
+    group = 'documentation'
+    source = sourceSets.main.allJava
+    destinationDir = reporting.file("jabref-docs")
+}
+
 test {
     useJUnitPlatform {
         excludeTags 'DatabaseTest', 'FetcherTest', 'GUITest'


### PR DESCRIPTION
This PR adds a JavaDoc "check" in the CI. Goal: our JavaDoc should not fail.

Follow-up to https://github.com/JabRef/jabref/pull/10244

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
