### PR TITLE
Add initial libYear config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ plugins {
     id 'idea'
 
     id 'org.openrewrite.rewrite' version '6.12.0'
+
+    id 'com.libyear.libyear-gradle-plugin' version '0.1.7'
 }
 
 // Enable following for debugging
@@ -827,4 +829,10 @@ jmh {
     warmupIterations = 5
     iterations = 10
     fork = 2
+}
+
+libyear {
+    configurations = ['compileClasspath']
+    failOnError = false
+    validator = singleArtifactMustNotBeOlderThan(years(20))
 }


### PR DESCRIPTION
Initial addition of [libYear](https://libyear.com/)

Before we can use that in "real" JabRef, we need to fix the exceptions. And maybe switch to released Java libraries.

```bash
koppor@DESKTOP-KAK953S MINGW64 /c/git-repositories/jabref (add-libyear)
$ ./gradlew reportLibyears

> Configure project :
Project : => 'org.jabref' Java module

> Task :reportLibyears
Cannot determine dependency age for "com.github.sialcasa.mvvmFX:mvvmfx-validation:f195849ca9" and repository "maven3" (reason: IllegalArgumentException).
Cannot determine dependency age for "com.tobiasdiez:easybind:2.2.1-SNAPSHOT" and repository "maven" (reason: IOException).
Cannot determine dependency age for "com.github.sialcasa.mvvmFX:mvvmfx-validation:f195849ca9" and repository "maven3" (reason: IllegalArgumentException: Response for URL https://jitpack.io/com/github/sialcasa/mvvmFX/mvvmfx-validation/f195849ca9/mvvmfx-validation-f195849ca9.jar did not contain a Last-Modified header).
Cannot determine dependency age for "com.tobiasdiez:easybind:2.2.1-SNAPSHOT" and repository "maven" (reason: IOException: Response for URL https://oss.sonatype.org/content/groups/public/com/tobiasdiez/easybind/2.2.1-SNAPSHOT/easybind-2.2.1-SNAPSHOT.jar returned 404).
Cannot determine dependency age for "com.vladsch.flexmark:flexmark-util-html:0.64.8" and repository "MavenRepo" (reason: IOException: Response for URL https://search.maven.org/solrsearch/select?q=g%3A%22com.vladsch.flexmark%22%20AND%20a%3A%22flexmark-util-html%22 returned 502).
Cannot determine dependency age for "com.vladsch.flexmark:flexmark-ext-emoji:0.64.8" and repository "MavenRepo" (reason: IOException: Response for URL https://search.maven.org/solrsearch/select?q=g%3A%22com.vladsch.flexmark%22%20AND%20a%3A%22flexmark-ext-emoji%22 returned 502).
Cannot determine dependency age for "org.glassfish.jersey.core:jersey-common:3.1.6" and repository "MavenRepo" (reason: IOException: Response for URL https://search.maven.org/solrsearch/select?q=g%3A%22org.glassfish.jersey.core%22%20AND%20a%3A%22jersey-common%22 returned 502).
Cannot determine dependency age for "org.glassfish.jersey.inject:jersey-hk2:3.1.6" and repository "MavenRepo" (reason: IOException: Response for URL https://search.maven.org/solrsearch/select?q=g%3A%22org.glassfish.jersey.inject%22%20AND%20a%3A%22jersey-hk2%22%20AND%20v%3A%224.0.0-M1%22 returned 502).
Cannot determine dependency age for "org.glassfish.hk2.external:aopalliance-repackaged:3.1.0" and repository "MavenRepo" (reason: IOException: Response for URL https://search.maven.org/solrsearch/select?q=g%3A%22org.glassfish.hk2.external%22%20AND%20a%3A%22aopalliance-repackaged%22 returned 502).
Cannot determine dependency age for "org.glassfish.jersey.containers:jersey-container-grizzly2-http:3.1.6" and repository "MavenRepo" (reason: IOException: Response for URL https://search.maven.org/solrsearch/select?q=g%3A%22org.glassfish.jersey.containers%22%20AND%20a%3A%22jersey-container-grizzly2-http%22%20AND%20v%3A%223.1.6%22 returned 502).
Cannot determine dependency age for "org.openjfx:javafx-fxml:22.0.1" and repository "MavenRepo" (reason: IOException: Response for URL https://search.maven.org/solrsearch/select?q=g%3A%22org.openjfx%22%20AND%20a%3A%22javafx-fxml%22%20AND%20v%3A%2222.0.1%22 returned 502).
Collected 7.6 decades  worth of libyears from 43 dependencies:
 -> 9.9 years  from commons-logging:commons-logging (1.2 => 1.3.2)
 -> 6.7 years  from eu.lestard:doc-annotations (0.2 => 0.3)
 -> 5.7 years  from com.squareup.okio:okio (1.15.0 => 3.9.0)
 -> 5.4 years  from com.squareup.okhttp3:okhttp (3.12.0 => 5.0.0-alpha.14)
 -> 4.7 years  from com.squareup.retrofit2:retrofit (2.6.1 => 2.11.0)
 -> 4.6 years  from org.codehaus.woodstox:stax2-api (4.2 => 4.2.2)
 -> 3.7 years  from at.favre.lib:hkdf (1.1.0 => 2.0.0)
 -> 3.3 years  from commons-validator:commons-validator (1.7 => 1.8.0)
 -> 2.9 years  from org.apache.httpcomponents:httpcore (4.4.13 => 4.4.16)
 -> 2.9 years  from org.apache.httpcomponents:httpcore-nio (4.4.13 => 4.4.16)
 -> 2.3 years  from org.scala-lang:scala-library (2.13.8 => 2.13.14)
 -> 2.2 years  from net.jodah:typetools (0.6.1 => 0.6.3)
 -> 2.2 years  from org.apache.httpcomponents:httpclient (4.5.13 => 4.5.14)
 -> 2.2 years  from org.apache.httpcomponents:httpmime (4.5.13 => 4.5.14)
 -> 1.8 years  from jakarta.validation:jakarta.validation-api (3.0.2 => 3.1.0-M2)
 -> 1.7 years  from jakarta.annotation:jakarta.annotation-api (2.1.1 => 3.0.0)
 -> 1.4 years  from com.github.hypfvieh:dbus-java-transport-native-unixsocket (4.2.1 => 5.0.0)
 -> 1.4 years  from com.github.hypfvieh:dbus-java-core (4.2.1 => 5.0.0)
 -> 1.2 years  from de.rototor.jeuclid:jeuclid-core (3.1.11 => 3.1.14)
 -> 1 years    from de.swiesend:secret-service (1.8.1-jdk17 => 2.0.1-alpha)
 -> 10.9 months from org.mariadb.jdbc:mariadb-java-client (2.7.9 => 3.3.3)
 -> 10.9 months from net.java.dev.jna:jna-platform (5.13.0 => 5.14.0)
 -> 10.9 months from net.java.dev.jna:jna (5.13.0 => 5.14.0)
 -> 9 months   from org.glassfish.jaxb:txw2 (4.0.3 => 4.0.5)
 -> 9 months   from org.glassfish.jaxb:jaxb-core (4.0.3 => 4.0.5)
 -> 9 months   from org.glassfish.jaxb:jaxb-runtime (4.0.3 => 4.0.5)
 -> 8.5 months from one.jpro.jproutils:tree-showing (0.2.2 => 0.2.3)
 -> 8.5 months from org.jetbrains:annotations (24.0.1 => 24.1.0)
 -> 6.8 months from org.fxmisc.flowless:flowless (0.7.2 => 0.7.3)
 -> 4.5 months from org.checkerframework:checker-qual (3.42.0 => 3.43.0)
 -> 4.5 months from com.github.weisj:jsvg (1.2.0 => 1.4.0)
 -> 2.8 months from org.tinylog:slf4j-tinylog (2.7.0 => 2.8.0-M1)
 -> 2.8 months from org.tinylog:tinylog-api (2.7.0 => 2.8.0-M1)
 -> 2.8 months from org.tinylog:tinylog-impl (2.7.0 => 2.8.0-M1)
 -> 2.4 months from com.google.code.gson:gson (2.10 => 2.10.1)
 -> 2 months   from net.synedra:validatorfx (0.5.0 => 0.5.1)
 -> 1.6 months from com.google.errorprone:error_prone_annotations (2.26.1 => 2.27.1)
 -> 1.6 months from com.google.guava:guava (33.1.0-jre => 33.2.0-jre)
 -> 1.3 months from org.glassfish.hk2:hk2-locator (3.0.6 => 4.0.0-M2)
 -> 7.1 days   from org.glassfish.hk2:hk2-utils (3.1.0 => 4.0.0-M2)
 -> 7.1 days   from org.glassfish.hk2:hk2-api (3.1.0 => 4.0.0-M2)
 -> 5 days     from com.dlsc.gemsfx:gemsfx (2.16.0 => 2.17.0)
 -> 2.8 days   from com.sun.istack:istack-commons-runtime (4.1.2 => 4.2.0)
```

