### PR TITLE
Add initial checker framework configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ plugins {
 
     id 'checkstyle'
 
+    // Homepage: https://github.com/kelloggm/checkerframework-gradle-plugin
+    id 'org.checkerframework' version '0.6.40'
+
     id 'project-report'
 
     id 'idea'
@@ -37,6 +40,8 @@ plugins {
 apply plugin: XjcPlugin
 
 apply from: 'eclipse.gradle'
+
+apply plugin: 'org.checkerframework'
 
 group = "org.jabref"
 version = project.findProperty('projVersion') ?: '100.0.0'
@@ -321,6 +326,11 @@ dependencies {
     rewrite("org.openrewrite.recipe:rewrite-logging-frameworks")
     rewrite("org.openrewrite.recipe:rewrite-testing-frameworks")
     rewrite("org.openrewrite.recipe:rewrite-migrate-java")
+
+    // checker framework
+    compileOnly 'org.checkerframework:checker-qual:3.44.0'
+    testCompileOnly 'org.checkerframework:checker-qual:3.44.0'
+    checkerFramework 'org.checkerframework:checker:3.44.0'
 
     configurations.checkstyle {
         resolutionStrategy.capabilitiesResolution.withCapability("com.google.collections:google-collections") {
@@ -612,6 +622,13 @@ jacocoTestReport {
 checkstyle {
     // will only run when called explicitly from the command line
     sourceSets = []
+}
+
+checkerFramework {
+    checkers = [
+        'org.checkerframework.checker.nullness.NullnessChecker'
+    ]
+    excludeTests = true
 }
 
 rewrite {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -143,6 +143,7 @@ open module org.jabref {
     uses org.eclipse.jgit.lib.GpgSigner;
 
     requires transitive org.jspecify;
+    requires org.checkerframework.checker.qual;
 
     // other libraries
     requires org.antlr.antlr4.runtime;

--- a/src/main/java/org/jabref/logic/pdf/search/PdfIndexer.java
+++ b/src/main/java/org/jabref/logic/pdf/search/PdfIndexer.java
@@ -55,8 +55,7 @@ public class PdfIndexer {
 
     private final FilePreferences filePreferences;
 
-    @Nullable
-    private final Directory indexDirectory;
+    private final @Nullable Directory indexDirectory;
 
     private IndexReader reader;
 


### PR DESCRIPTION
To check `@NonNull`, there is the [checker-framework](https://github.com/typetools/checker-framework)

There is a [gradle plugin](https://github.com/kelloggm/checkerframework-gradle-plugin).

When using, I get

```
java.lang.Error: Backtrace:
        at org.checkerframework.javacutil.AnnotationBuilder.fromClass(AnnotationBuilder.java:188)
        at org.checkerframework.javacutil.AnnotationBuilder.fromClass(AnnotationBuilder.java:156)
...
error: AnnotationBuilder: fromClass can't load class org.checkerframework.dataflow.qual.Deterministic
  Is the class in checker-qual.jar?
...
> Task :compileJava FAILED

FAILURE: Build failed with an exception.
```

- Risk: JDK 23: https://github.com/kelloggm/checkerframework-gradle-plugin/issues/272

---

- [ ] Blocked by https://github.com/kelloggm/checkerframework-gradle-plugin/issues/275
- [ ] Fix `null` issues

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
