### PR TITLE
Fix 11338

### DIFF
--- a/src/main/java/org/jabref/logic/bst/BstPreviewLayout.java
+++ b/src/main/java/org/jabref/logic/bst/BstPreviewLayout.java
@@ -9,7 +9,6 @@ import org.jabref.logic.cleanup.ConvertToBibtexCleanup;
 import org.jabref.logic.formatter.bibtexfields.RemoveNewlinesFormatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.format.LatexToUnicodeFormatter;
-import org.jabref.logic.layout.format.RemoveLatexCommandsFormatter;
 import org.jabref.logic.layout.format.RemoveTilde;
 import org.jabref.logic.preview.PreviewLayout;
 import org.jabref.logic.util.StandardFileType;
@@ -79,7 +78,6 @@ public final class BstPreviewLayout implements PreviewLayout {
         result = result.replace("''", "\"");
         // Final cleanup
         result = new RemoveNewlinesFormatter().format(result);
-        result = new RemoveLatexCommandsFormatter().format(result);
         result = new RemoveTilde().format(result);
         result = result.trim().replaceAll("  +", " ");
         return result;

--- a/src/main/java/org/jabref/logic/integrity/LatexIntegrityChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/LatexIntegrityChecker.java
@@ -43,6 +43,7 @@ public class LatexIntegrityChecker implements EntryChecker {
     private static final ResourceBundle ERROR_MESSAGES = ENGINE.getPackages().get(0).getErrorMessageBundle();
     private static final Set<ErrorCode> EXCLUDED_ERRORS = new HashSet<>();
 
+    // if something changes here, please also adapt org.jabref.logic.layout.format.LatexToHtmlFormatter
     static {
         SnugglePackage snugglePackage = ENGINE.getPackages().get(0);
         snugglePackage.addComplexCommand("textgreater", false, 0, TEXT_MODE_ONLY, null, null, null);

--- a/src/main/java/org/jabref/logic/layout/format/LatexToHtmlFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/LatexToHtmlFormatter.java
@@ -1,0 +1,89 @@
+package org.jabref.logic.layout.format;
+
+import java.io.IOException;
+
+import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.layout.LayoutFormatter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.ed.ph.snuggletex.InputError;
+import uk.ac.ed.ph.snuggletex.SnuggleEngine;
+import uk.ac.ed.ph.snuggletex.SnuggleInput;
+import uk.ac.ed.ph.snuggletex.SnugglePackage;
+import uk.ac.ed.ph.snuggletex.SnuggleSession;
+import uk.ac.ed.ph.snuggletex.WebPageOutputOptions;
+
+import static uk.ac.ed.ph.snuggletex.definitions.Globals.TEXT_MODE_ONLY;
+
+/**
+ * This formatter converts LaTeX commands to HTML
+ */
+public class LatexToHtmlFormatter extends Formatter implements LayoutFormatter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LatexToHtmlFormatter.class);
+
+    private static final SnuggleEngine ENGINE = new SnuggleEngine();
+    private static final SnuggleSession SESSION;
+
+    // Code adapted from org.jabref.logic.integrity.LatexIntegrityChecker
+    static {
+        SnugglePackage snugglePackage = ENGINE.getPackages().get(0);
+        snugglePackage.addComplexCommand("textgreater", false, 0, TEXT_MODE_ONLY, null, null, null);
+        snugglePackage.addComplexCommand("textless", false, 0, TEXT_MODE_ONLY, null, null, null);
+        snugglePackage.addComplexCommand("textbackslash", false, 0, TEXT_MODE_ONLY, null, null, null);
+        snugglePackage.addComplexCommand("textbar", false, 0, TEXT_MODE_ONLY, null, null, null);
+        // ENGINE.getPackages().get(0).addComplexCommandOneArg()
+        // engine.getPackages().get(0).addComplexCommandOneArg("text", false, ALL_MODES,LR, StyleDeclarationInterpretation.NORMALSIZE, null, TextFlowContext.ALLOW_INLINE);
+
+        SESSION = ENGINE.createSession();
+        SESSION.getConfiguration().setFailingFast(true);
+    }
+
+    @Override
+    public String getName() {
+        return Localization.lang("LaTeX to HTML");
+    }
+
+    @Override
+    public String getKey() {
+        return "latex_to_html";
+    }
+
+    @Override
+    public String format(String latexInput) {
+        SESSION.reset();
+        latexInput = latexInput.replace("\\providecommand", "\\newcommand");
+        LOGGER.trace("Parsing {}", latexInput);
+        SnuggleInput input = new SnuggleInput(latexInput);
+        try {
+            SESSION.parseInput(input);
+        } catch (IOException e) {
+            LOGGER.error("Error at parsing", e);
+            return latexInput;
+        }
+
+        WebPageOutputOptions webPageOutputOptions = new WebPageOutputOptions();
+        webPageOutputOptions.setHtml5(true);
+        String result = SESSION.buildWebPageString(webPageOutputOptions);
+
+        if (!SESSION.getErrors().isEmpty()) {
+            InputError error = SESSION.getErrors().getFirst();
+            LOGGER.error("Error at parsing", error.toString());
+            return "Error: " + error;
+        }
+
+        return result;
+    }
+
+    @Override
+    public String getDescription() {
+        return Localization.lang("Converts LaTeX encoding to HTML.");
+    }
+
+    @Override
+    public String getExampleInput() {
+        return "M{\\\"{o}}nch";
+    }
+}

--- a/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -23,6 +23,9 @@ public class LatexToUnicodeFormatter extends Formatter implements LayoutFormatte
 
     @Override
     public String format(String inField) {
+        // Formatter is not able to handle round braces
+        inField = inField.replace("\\(", "$");
+        inField = inField.replace("\\)", "$");
         return LatexToUnicodeAdapter.format(inField);
     }
 

--- a/src/main/resources/tinylog.properties
+++ b/src/main/resources/tinylog.properties
@@ -11,3 +11,5 @@ exception = strip: jdk.internal
 level@org.jabref.gui.maintable.PersistenceVisualStateTable = debug
 
 level@org.jabref.http.server.Server = debug
+
+level@org.jabref.logic.layout.format.LatexToHtmlFormatter = trace

--- a/src/test/java/org/jabref/logic/bst/BstPreviewLayoutTest.java
+++ b/src/test/java/org/jabref/logic/bst/BstPreviewLayoutTest.java
@@ -46,6 +46,27 @@ class BstPreviewLayoutTest {
     }
 
     @Test
+    public void generatePreviewForUnicodeUsingAbbr() throws Exception {
+        BstPreviewLayout bstPreviewLayout = new BstPreviewLayout(Path.of(BstPreviewLayoutTest.class.getResource("abbrv.bst").toURI()));
+        String preview = bstPreviewLayout.generatePreview(new BibEntry().withField(StandardField.AUTHOR, "{\\O}ie, Gunvor"), bibDatabaseContext);
+        assertEquals("G. Øie.", preview);
+    }
+
+    @Test
+    public void generatePreviewForUnicodeNameUsingIeee() throws Exception {
+        BstPreviewLayout bstPreviewLayout = new BstPreviewLayout(Path.of(ClassLoader.getSystemResource("bst/IEEEtran.bst").toURI()));
+        String preview = bstPreviewLayout.generatePreview(new BibEntry().withField(StandardField.AUTHOR, "{\\O}ie, Gunvor"), bibDatabaseContext);
+        assertEquals("G. Øie.", preview);
+    }
+
+    @Test
+    public void generatePreviewForUnicodeTitleUsingIeee() throws Exception {
+        BstPreviewLayout bstPreviewLayout = new BstPreviewLayout(Path.of(ClassLoader.getSystemResource("bst/IEEEtran.bst").toURI()));
+        String preview = bstPreviewLayout.generatePreview(new BibEntry().withField(StandardField.TITLE, "Linear programming design of semi-digital {FIR} filter and {\\(\\Sigma\\)}{\\(\\Delta\\)} modulator for {VDSL2} transmitter"), bibDatabaseContext);
+        assertEquals("Linear programming design of semi-digital FIR filter and σδ modulator for VDSL2 transmitter", preview);
+    }
+
+    @Test
     public void generatePreviewForSliceTheoremPaperUsingIEEE() throws Exception {
         BstPreviewLayout bstPreviewLayout = new BstPreviewLayout(Path.of(ClassLoader.getSystemResource("bst/IEEEtran.bst").toURI()));
         String preview = bstPreviewLayout.generatePreview(getSliceTheoremPaper(), bibDatabaseContext);

--- a/src/test/java/org/jabref/logic/bst/BstPreviewLayoutTest.java
+++ b/src/test/java/org/jabref/logic/bst/BstPreviewLayoutTest.java
@@ -2,7 +2,6 @@ package org.jabref.logic.bst;
 
 import java.nio.file.Path;
 
-import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -11,7 +10,6 @@ import org.jabref.model.entry.types.StandardEntryType;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 
 class BstPreviewLayoutTest {
 
@@ -22,7 +20,6 @@ class BstPreviewLayoutTest {
         BstPreviewLayout bstPreviewLayout = new BstPreviewLayout(Path.of(BstPreviewLayoutTest.class.getResource("abbrv.bst").toURI()));
         BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "Oliver Kopp")
                                        .withField(StandardField.TITLE, "Thoughts on Development");
-        BibDatabase bibDatabase = mock(BibDatabase.class);
         String preview = bstPreviewLayout.generatePreview(entry, bibDatabaseContext);
         assertEquals("O. Kopp. Thoughts on development.", preview);
     }
@@ -33,7 +30,6 @@ class BstPreviewLayoutTest {
         BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "Oliver Kopp")
                                        .withField(StandardField.TITLE, "Thoughts on Development")
                                        .withField(StandardField.MONTH, "#May#");
-        BibDatabase bibDatabase = mock(BibDatabase.class);
         String preview = bstPreviewLayout.generatePreview(entry, bibDatabaseContext);
         assertEquals("O. Kopp. Thoughts on development, May.", preview);
     }
@@ -63,6 +59,29 @@ class BstPreviewLayoutTest {
     public void generatePreviewForUnicodeTitleUsingIeee() throws Exception {
         BstPreviewLayout bstPreviewLayout = new BstPreviewLayout(Path.of(ClassLoader.getSystemResource("bst/IEEEtran.bst").toURI()));
         String preview = bstPreviewLayout.generatePreview(new BibEntry().withField(StandardField.TITLE, "Linear programming design of semi-digital {FIR} filter and {\\(\\Sigma\\)}{\\(\\Delta\\)} modulator for {VDSL2} transmitter"), bibDatabaseContext);
+        assertEquals("Linear programming design of semi-digital FIR filter and σδ modulator for VDSL2 transmitter", preview);
+    }
+
+    @Test
+    public void generatePreviewForComplexEntryUsingIeee() throws Exception {
+        BstPreviewLayout bstPreviewLayout = new BstPreviewLayout(Path.of(ClassLoader.getSystemResource("bst/IEEEtran.bst").toURI()));
+
+        BibEntry testEntry = new BibEntry(StandardEntryType.InProceedings)
+                .withCitationKey("DBLP:conf/iscas/SadeghifarWG14")
+                // .withField(StandardField.AUTHOR, "Mohammad Reza Sadeghifar and J. Jacob Wikner and Oscar Gustafsson")
+                //.withField(StandardField.TITLE, "Linear programming design of semi-digital {FIR} filter and {\\(\\Sigma\\)}{\\(\\Delta\\)} modulator for {VDSL2} transmitter")
+                .withField(StandardField.BOOKTITLE, "{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014")
+                // .withField(StandardField.PAGES, "2465--2468")
+                // .withField(StandardField.PUBLISHER, "{IEEE}")
+                // .withField(StandardField.YEAR, "2014")
+                // .withField(StandardField.URL, "https://doi.org/10.1109/ISCAS.2014.6865672")
+                // .withField(StandardField.DOI, "10.1109/ISCAS.2014.6865672")
+                // .withField(StandardField.TIMESTAMP, "Sat, 05 Sep 2020 18:07:30 +0200")
+                // .withField(new UnknownField("biburl"), "https://dblp.org/rec/conf/iscas/SadeghifarWG14.bib")
+                // .withField(new UnknownField("bibsource"), "dblp computer science bibliography, https://dblp.org");
+                ;
+
+        String preview = bstPreviewLayout.generatePreview(testEntry, bibDatabaseContext);
         assertEquals("Linear programming design of semi-digital FIR filter and σδ modulator for VDSL2 transmitter", preview);
     }
 

--- a/src/test/java/org/jabref/logic/layout/format/LatexToHtmlFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToHtmlFormatterTest.java
@@ -1,0 +1,77 @@
+package org.jabref.logic.layout.format;
+
+import org.jsoup.Jsoup;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LatexToHtmlFormatterTest {
+
+    final LatexToHtmlFormatter formatter = new LatexToHtmlFormatter();
+
+    @ParameterizedTest(name = "{0}")
+    // Non-working conversions were filed at https://github.com/davemckain/snuggletex/issues/7
+    @CsvSource({
+            "plainFormat, aaa, aaa",
+            "formatUmlautLi, ä, {\\\"{a}}",
+            "formatUmlautCa, Ä, {\\\"{A}}",
+            // "formatUmlautLi, ı, \\i",
+            // "formatUmlautCi, ı, {\\i}",
+            "unknownCommandToSpan, '<span class=\"mbox\">-</span>', '\\mbox{-}'",
+            "formatTextit, <i>text</i>, \\textit{text}",
+            "escapedDollarSign, $, \\$",
+            "curlyBracesAreRemoved, test, {test}",
+            "curlyBracesAreRemovedInLongerText, a longer test there, a longer {test} there",
+            "longConference, 'IEEE International Symposium on Circuits and Systems, ISCAS 2014, Melbourne, Victoria, Australia, June 1-5, 2014', '{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014'",
+            "longLatexedConferenceKeepsLatexCommands, 'in <em>IEEE International Symposium on Circuits and Systems, ISCAS 2014, Melbourne, Victoria, Australia, June 1-5, 2014.</em>', 'in \\emph{{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014.}'",
+            "formatExample, Mönch, Mönch",
+            "iWithDiaresisAndUnnecessaryBraces, ï, {\\\"{i}}",
+            "upperCaseIWithDiaresis, Ï, \\\"{I}",
+            // "polishName, Łęski, \\L\\k{e}ski",
+            // "doubleCombiningAccents, ώ, $\\acute{\\omega}$", // disabled, because not supported by SnuggleTeX yet - see https://github.com/davemckain/snuggletex/issues/5
+            // "combiningAccentsCase1, ḩ, {\\c{h}}",
+            // "ignoreUnknownCommandWithoutArgument, '', \\aaaa",
+            // "ignoreUnknownCommandWithArgument, '', \\aaaa{bbbb}",
+            // "removeUnknownCommandWithEmptyArgument, '', \\aaaa{}",
+            // "sWithCaron, Š, {\\v{S}}",
+            // "iWithDiaresisAndEscapedI, ı̈, \\\"{\\i}",
+            "tildeN, Montaña, Monta\\~{n}a",
+            // "acuteNLongVersion, Maliński, Mali\\'{n}ski",
+            // "acuteNLongVersion, MaliŃski, Mali\\'{N}ski",
+            // "acuteNShortVersion, Maliński, Mali\\'nski",
+            // "acuteNShortVersion, MaliŃski, Mali\\'Nski",
+            "apostrophN, Mali’nski, Mali'nski",
+            "apostrophN, Mali’Nski, Mali'Nski",
+            "apostrophO, L’oscillation, L'oscillation",
+            "apostrophC, O’Connor, O'Connor",
+            // (wrong LaTeX) "preservationOfSingleUnderscore, Lorem ipsum_lorem ipsum, Lorem ipsum_lorem ipsum",
+            // (wrong LaTeX) "conversionOfUnderscoreWithBraces, Lorem ipsum_(lorem ipsum), Lorem ipsum_{lorem ipsum}",
+            // "conversionOfOrdinal1st, 1ˢᵗ, 1\\textsuperscript{st}",
+            // "conversionOfOrdinal2nd, 2ⁿᵈ, 2\\textsuperscript{nd}",
+            // "conversionOfOrdinal3rd, 3ʳᵈ, 3\\textsuperscript{rd}",
+            // "conversionOfOrdinal4th, 4ᵗʰ, 4\\textsuperscript{th}",
+            // "conversionOfOrdinal9th, 9ᵗʰ, 9\\textsuperscript{th}",
+            // "unicodeNames, 'Øie, Gunvor', '{\\O}ie, Gunvor'"
+    })
+    void formatterTest(String name, String expected, String input) {
+        String htmlResult = formatter.format(input);
+        String result = Jsoup.parse(htmlResult).body().html();
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @CsvSource({"equationsSingleSymbol, σ, $\\sigma$",
+            "equationsMoreComplicatedFormatting, A 32 mA ΣΔ -modulator, A 32~{mA} {$\\Sigma\\Delta$}-modulator",
+            "equationsMoreComplicatedFormattingSigmaDeltaBraceVariant, Σ Δ, {\\(\\Sigma\\)}{\\(\\Delta\\)}",
+            "equationsMoreComplicatedFormattingSigmaDeltaDollarVariant, Σ Δ, {{$\\Sigma$}}{{$\\Delta$}}",
+            "longTitle, Linear programming design of semi-digital FIR filter and Σ Δ modulator for VDSL2 transmitter, Linear programming design of semi-digital {FIR} filter and {\\(\\Sigma\\)}{\\(\\Delta\\)} modulator for {VDSL2} transmitter",
+            "chi, χ, $\\chi$",
+            "iWithDiaresis, ï, \\\"{i}"
+    })
+    void math(String name, String expected, String input) {
+        String htmlResult = formatter.format(input);
+        String result = Jsoup.parse(htmlResult).body().text();
+        assertEquals(expected, result);
+    }
+}

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -11,239 +11,63 @@ class LatexToUnicodeFormatterTest {
 
     final LatexToUnicodeFormatter formatter = new LatexToUnicodeFormatter();
 
-    @Test
-    void plainFormat() {
-        assertEquals("aaa", formatter.format("aaa"));
-    }
-
-    @Test
-    void formatUmlaut() {
-        assertEquals("ä", formatter.format("{\\\"{a}}"));
-        assertEquals("Ä", formatter.format("{\\\"{A}}"));
-    }
-
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}")
     @CsvSource({
-            "ı, \\i",
-            "ı, {\\i}"
+            "plainFormat, aaa, aaa",
+            "formatUmlautLi, ä, {\\\"{a}}",
+            "formatUmlautCa, Ä, {\\\"{A}}",
+            "formatUmlautLi, ı, \\i",
+            "formatUmlautCi, ı, {\\i}",
+            "preserveUnknownCommand, '\\mbox{-}', '\\mbox{-}'",
+            "formatTextit, \uD835\uDC61\uD835\uDC52\uD835\uDC65\uD835\uDC61, \\textit{text}",
+            "escapedDollarSign, $, \\$",
+            "equationsSingleSymbol, σ, $\\sigma$",
+            "curlyBracesAreRemoved, test, {test}",
+            "curlyBracesAreRemovedInLongerText, a longer test there, a longer {test} there",
+            "equationsMoreComplicatedFormatting, A 32 mA ΣΔ-modulator, A 32~{mA} {$\\Sigma\\Delta$}-modulator",
+            "equationsMoreComplicatedFormattingSigmaDeltaBraceVariant, ΣΔ, {\\(\\Sigma\\)}{\\(\\Delta\\)}",
+            "equationsMoreComplicatedFormattingSigmaDeltaDollarVariant, ΣΔ, {{$\\Sigma$}}{{$\\Delta$}}",
+            "longTitle, Linear programming design of semi-digital FIR filter and ΣΔ modulator for VDSL2 transmitter, Linear programming design of semi-digital {FIR} filter and {\\(\\Sigma\\)}{\\(\\Delta\\)} modulator for {VDSL2} transmitter",
+            "longConference, 'IEEE International Symposium on Circuits and Systems, ISCAS 2014, Melbourne, Victoria, Australia, June 1-5, 2014', '{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014'",
+            "longLatexedConferenceKeepsLatexCommands, 'in \\emph{{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014.}', 'in \\emph{{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014.}'",
+            "formatExample, Mönch, Mönch",
+            "chi, χ, $\\chi$",
+            "sWithCaron, Š, {\\v{S}}",
+            "iWithDiaresis, ï, \\\"{i}",
+            "iWithDiaresisAndEscapedI, ı̈, \\\"{\\i}",
+            "iWithDiaresisAndUnnecessaryBraces, ï, {\\\"{i}}",
+            "upperCaseIWithDiaresis, Ï, \\\"{I}",
+            "polishName, Łęski, \\L\\k{e}ski",
+            "doubleCombiningAccents, ώ, $\\acute{\\omega}$",
+            "combiningAccentsCase1, ḩ, {\\c{h}}",
+            "keepUnknownCommandWithoutArgument, \\aaaa, \\aaaa",
+            "keepUnknownCommandWithArgument, \\aaaa{bbbb}, \\aaaa{bbbb}",
+            "keepUnknownCommandWithEmptyArgument, \\aaaa{}, \\aaaa{}",
+            "tildeN, Montaña, Monta\\~{n}a",
+            "acuteNLongVersion, Maliński, Mali\\'{n}ski",
+            "acuteNLongVersion, MaliŃski, Mali\\'{N}ski",
+            "acuteNShortVersion, Maliński, Mali\\'nski",
+            "acuteNShortVersion, MaliŃski, Mali\\'Nski",
+            "apostrophN, Mali'nski, Mali'nski",
+            "apostrophN, Mali'Nski, Mali'Nski",
+            "apostrophO, L'oscillation, L'oscillation",
+            "apostrophC, O'Connor, O'Connor",
+            "preservationOfSingleUnderscore, Lorem ipsum_lorem ipsum, Lorem ipsum_lorem ipsum",
+            "conversionOfUnderscoreWithBraces, Lorem ipsum_(lorem ipsum), Lorem ipsum_{lorem ipsum}",
+            "conversionOfOrdinal1st, 1ˢᵗ, 1\\textsuperscript{st}",
+            "conversionOfOrdinal2nd, 2ⁿᵈ, 2\\textsuperscript{nd}",
+            "conversionOfOrdinal3rd, 3ʳᵈ, 3\\textsuperscript{rd}",
+            "conversionOfOrdinal4th, 4ᵗʰ, 4\\textsuperscript{th}",
+            "conversionOfOrdinal9th, 9ᵗʰ, 9\\textsuperscript{th}",
+            "unicodeNames, 'Øie, Gunvor', '{\\O}ie, Gunvor'"
     })
-    void smallIwithoutDot(String expected, String input) {
+    void formatterTest(String name, String expected, String input) {
         assertEquals(expected, formatter.format(input));
-    }
-
-    @Test
-    void preserveUnknownCommand() {
-        assertEquals("\\mbox{-}", formatter.format("\\mbox{-}"));
-    }
-
-    @Test
-    void formatTextit() {
-        // See #1464
-        assertEquals("\uD835\uDC61\uD835\uDC52\uD835\uDC65\uD835\uDC61", formatter.format("\\textit{text}"));
-    }
-
-    @Test
-    void escapedDollarSign() {
-        assertEquals("$", formatter.format("\\$"));
-    }
-
-    @Test
-    void equationsSingleSymbol() {
-        assertEquals("σ", formatter.format("$\\sigma$"));
-    }
-
-    @Test
-    void curlyBracesAreRemoved() {
-        assertEquals("test", formatter.format("{test}"));
-    }
-
-    @Test
-    void curlyBracesAreRemovedInLongerText() {
-        assertEquals("a longer test there", formatter.format("a longer {test} there"));
-    }
-
-    @Test
-    void equationsMoreComplicatedFormatting() {
-        assertEquals("A 32 mA ΣΔ-modulator", formatter.format("A 32~{mA} {$\\Sigma\\Delta$}-modulator"));
-    }
-
-    @Test
-    void equationsMoreComplicatedFormattingSigmaDeltaBraceVariant() {
-        assertEquals("ΣΔ", formatter.format("{\\(\\Sigma\\)}{\\(\\Delta\\)}"));
-    }
-
-    @Test
-    void equationsMoreComplicatedFormattingSigmaDeltaDollarVariant() {
-        assertEquals("ΣΔ", formatter.format("{{$\\Sigma$}}{{$\\Delta$}}"));
-    }
-
-    @Test
-    void longTitle() {
-        assertEquals("Linear programming design of semi-digital FIR filter and ΣΔ modulator for VDSL2 transmitter", formatter.format("Linear programming design of semi-digital {FIR} filter and {\\(\\Sigma\\)}{\\(\\Delta\\)} modulator for {VDSL2} transmitter"));
-    }
-
-    @Test
-    void longConference() {
-        assertEquals("IEEE International Symposium on Circuits and Systems, ISCAS 2014, Melbourne, Victoria, Australia, June 1-5, 2014", formatter.format("{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014"));
-    }
-
-    @Test
-    void longLatexedConferenceKeepsLatexCommands() {
-        assertEquals("in \\emph{{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014.}", formatter.format("in \\emph{{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014.}"));
-    }
-
-    @Test
-    void formatExample() {
-        assertEquals("Mönch", formatter.format(formatter.getExampleInput()));
-    }
-
-    @Test
-    void chi() {
-        // See #1464
-        assertEquals("χ", formatter.format("$\\chi$"));
-    }
-
-    @Test
-    void sWithCaron() {
-        // Bug #1264
-        assertEquals("Š", formatter.format("{\\v{S}}"));
-    }
-
-    @Test
-    void iWithDiaresis() {
-        assertEquals("ï", formatter.format("\\\"{i}"));
-    }
-
-    @Test
-    void iWithDiaresisAndEscapedI() {
-        // this might look strange in the test, but is actually a correct translation and renders identically to the above example in the UI
-        assertEquals("ı̈", formatter.format("\\\"{\\i}"));
-    }
-
-    @Test
-    void iWithDiaresisAndUnnecessaryBraces() {
-        assertEquals("ï", formatter.format("{\\\"{i}}"));
-    }
-
-    @Test
-    void upperCaseIWithDiaresis() {
-        assertEquals("Ï", formatter.format("\\\"{I}"));
-    }
-
-    @Test
-    void polishName() {
-        assertEquals("Łęski", formatter.format("\\L\\k{e}ski"));
-    }
-
-    @Test
-    void doubleCombiningAccents() {
-        assertEquals("ώ", formatter.format("$\\acute{\\omega}$"));
-    }
-
-    @Test
-    void combiningAccentsCase1() {
-        assertEquals("ḩ", formatter.format("{\\c{h}}"));
     }
 
     @Disabled("This is not a standard LaTeX command. It is debatable why we should convert this.")
     @Test
     void combiningAccentsCase2() {
         assertEquals("a͍", formatter.format("\\spreadlips{a}"));
-    }
-
-    @Test
-    void keepUnknownCommandWithoutArgument() {
-        assertEquals("\\aaaa", formatter.format("\\aaaa"));
-    }
-
-    @Test
-    void keepUnknownCommandWithArgument() {
-        assertEquals("\\aaaa{bbbb}", formatter.format("\\aaaa{bbbb}"));
-    }
-
-    @Test
-    void keepUnknownCommandWithEmptyArgument() {
-        assertEquals("\\aaaa{}", formatter.format("\\aaaa{}"));
-    }
-
-    @Test
-    void tildeN() {
-        assertEquals("Montaña", formatter.format("Monta\\~{n}a"));
-    }
-
-    @Test
-    void acuteNLongVersion() {
-        assertEquals("Maliński", formatter.format("Mali\\'{n}ski"));
-        assertEquals("MaliŃski", formatter.format("Mali\\'{N}ski"));
-    }
-
-    @Test
-    void acuteNShortVersion() {
-        assertEquals("Maliński", formatter.format("Mali\\'nski"));
-        assertEquals("MaliŃski", formatter.format("Mali\\'Nski"));
-    }
-
-    @Test
-    void apostrophN() {
-        assertEquals("Mali'nski", formatter.format("Mali'nski"));
-        assertEquals("Mali'Nski", formatter.format("Mali'Nski"));
-    }
-
-    @Test
-    void apostrophO() {
-        assertEquals("L'oscillation", formatter.format("L'oscillation"));
-    }
-
-    @Test
-    void apostrophC() {
-        assertEquals("O'Connor", formatter.format("O'Connor"));
-    }
-
-    @Test
-    void preservationOfSingleUnderscore() {
-        assertEquals("Lorem ipsum_lorem ipsum", formatter.format("Lorem ipsum_lorem ipsum"));
-    }
-
-    @Test
-    void conversionOfUnderscoreWithBraces() {
-        assertEquals("Lorem ipsum_(lorem ipsum)", formatter.format("Lorem ipsum_{lorem ipsum}"));
-    }
-
-    /**
-     * <a href="https://github.com/JabRef/jabref/issues/5547">Issue 5547</a>
-     */
-    @Test
-    void twoDifferentMacrons() {
-        assertEquals("Puṇya-pattana-vidyā-pı̄ṭhādhi-kṛtaiḥ prā-kaśyaṃ nı̄taḥ", formatter.format("Pu{\\d{n}}ya-pattana-vidy{\\={a}}-p{\\={\\i}}{\\d{t}}h{\\={a}}dhi-k{\\d{r}}tai{\\d{h}} pr{\\={a}}-ka{{\\'{s}}}ya{\\d{m}} n{\\={\\i}}ta{\\d{h}}"));
-    }
-
-    @Test
-    void conversionOfOrdinal1st() {
-        assertEquals("1ˢᵗ", formatter.format("1\\textsuperscript{st}"));
-    }
-
-    @Test
-    void conversionOfOrdinal2nd() {
-        assertEquals("2ⁿᵈ", formatter.format("2\\textsuperscript{nd}"));
-    }
-
-    @Test
-    void conversionOfOrdinal3rd() {
-        assertEquals("3ʳᵈ", formatter.format("3\\textsuperscript{rd}"));
-    }
-
-    @Test
-    void conversionOfOrdinal4th() {
-        assertEquals("4ᵗʰ", formatter.format("4\\textsuperscript{th}"));
-    }
-
-    @Test
-    void conversionOfOrdinal9th() {
-        assertEquals("9ᵗʰ", formatter.format("9\\textsuperscript{th}"));
-    }
-
-    @Test
-    public void unicodeNames() {
-        assertEquals("Øie, Gunvor", formatter.format("{\\O}ie, Gunvor"));
     }
 }

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -53,8 +53,43 @@ class LatexToUnicodeFormatterTest {
     }
 
     @Test
+    void curlyBracesAreRemoved() {
+        assertEquals("test", formatter.format("{test}"));
+    }
+
+    @Test
+    void curlyBracesAreRemovedInLongerText() {
+        assertEquals("a longer test there", formatter.format("a longer {test} there"));
+    }
+
+    @Test
     void equationsMoreComplicatedFormatting() {
         assertEquals("A 32 mA ΣΔ-modulator", formatter.format("A 32~{mA} {$\\Sigma\\Delta$}-modulator"));
+    }
+
+    @Test
+    void equationsMoreComplicatedFormattingSigmaDeltaBraceVariant() {
+        assertEquals("ΣΔ", formatter.format("{\\(\\Sigma\\)}{\\(\\Delta\\)}"));
+    }
+
+    @Test
+    void equationsMoreComplicatedFormattingSigmaDeltaDollarVariant() {
+        assertEquals("ΣΔ", formatter.format("{{$\\Sigma$}}{{$\\Delta$}}"));
+    }
+
+    @Test
+    void longTitle() {
+        assertEquals("Linear programming design of semi-digital FIR filter and ΣΔ modulator for VDSL2 transmitter", formatter.format("Linear programming design of semi-digital {FIR} filter and {\\(\\Sigma\\)}{\\(\\Delta\\)} modulator for {VDSL2} transmitter"));
+    }
+
+    @Test
+    void longConference() {
+        assertEquals("IEEE International Symposium on Circuits and Systems, ISCAS 2014, Melbourne, Victoria, Australia, June 1-5, 2014", formatter.format("{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014"));
+    }
+
+    @Test
+    void longLatexedConferenceKeepsLatexCommands() {
+        assertEquals("in \\emph{{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014.}", formatter.format("in \\emph{{IEEE} International Symposium on Circuits and Systems, {ISCAS} 2014, Melbourne, Victoria, Australia, June 1-5, 2014.}"));
     }
 
     @Test
@@ -205,5 +240,10 @@ class LatexToUnicodeFormatterTest {
     @Test
     void conversionOfOrdinal9th() {
         assertEquals("9ᵗʰ", formatter.format("9\\textsuperscript{th}"));
+    }
+
+    @Test
+    public void unicodeNames() {
+        assertEquals("Øie, Gunvor", formatter.format("{\\O}ie, Gunvor"));
     }
 }

--- a/src/test/java/org/jabref/logic/layout/format/RemoveLatexCommandsFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/RemoveLatexCommandsFormatterTest.java
@@ -1,61 +1,32 @@
 package org.jabref.logic.layout.format;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RemoveLatexCommandsFormatterTest {
 
-    private RemoveLatexCommandsFormatter formatter;
-
-    @BeforeEach
-    public void setUp() {
-        formatter = new RemoveLatexCommandsFormatter();
-    }
-
-    @Test
-    public void withoutLatexCommandsUnmodified() {
-        assertEquals("some text", formatter.format("some text"));
-    }
-
-    @Test
-    public void singleCommandWiped() {
-        assertEquals("", formatter.format("\\sometext"));
-    }
-
-    @Test
-    public void singleSpaceAfterCommandRemoved() {
-        assertEquals("text", formatter.format("\\some text"));
-    }
-
-    @Test
-    public void multipleSpacesAfterCommandRemoved() {
-        assertEquals("text", formatter.format("\\some     text"));
-    }
-
-    @Test
-    public void escapedBackslashBecomesBackslash() {
-        assertEquals("\\", formatter.format("\\\\"));
-    }
-
-    @Test
-    public void escapedBackslashFollowedByTextBecomesBackslashFollowedByText() {
-        assertEquals("\\some text", formatter.format("\\\\some text"));
-    }
-
-    @Test
-    public void escapedBackslashKept() {
-        assertEquals("\\some text\\", formatter.format("\\\\some text\\\\"));
-    }
-
-    @Test
-    public void escapedUnderscoreReplaces() {
-        assertEquals("some_text", formatter.format("some\\_text"));
-    }
+    private RemoveLatexCommandsFormatter formatter = new RemoveLatexCommandsFormatter();
 
     @Test
     public void exampleUrlCorrectlyCleaned() {
         assertEquals("http://pi.informatik.uni-siegen.de/stt/36_2/./03_Technische_Beitraege/ZEUS2016/beitrag_2.pdf", formatter.format("http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf"));
+    }
+
+    @ParameterizedTest(name = "expected={0}, input={1}")
+    @CsvSource({
+            "some text, some text",                 // withoutLatexCommandsUnmodified
+            "'', \\sometext",                       // singleCommandWiped
+            "text, \\some text",                    // singleSpaceAfterCommandRemoved
+            "text, \\some     text",                // multipleSpacesAfterCommandRemoved
+            "\\, \\\\",                             // escapedBackslashBecomesBackslash
+            "\\some text, \\\\some text",           // escapedBackslashFollowedByTextBecomesBackslashFollowedByText
+            "\\some text\\, \\\\some text\\\\",     // escapedBackslashKept
+            "some_text, some\\_text"                // escapedUnderscoreReplaces
+    })
+    public void formatterTest(String expected, String input) {
+        assertEquals(expected, formatter.format(input));
     }
 }

--- a/src/test/java/org/jabref/logic/layout/format/RemoveLatexCommandsFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/RemoveLatexCommandsFormatterTest.java
@@ -15,16 +15,16 @@ class RemoveLatexCommandsFormatterTest {
         assertEquals("http://pi.informatik.uni-siegen.de/stt/36_2/./03_Technische_Beitraege/ZEUS2016/beitrag_2.pdf", formatter.format("http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf"));
     }
 
-    @ParameterizedTest(name = "expected={0}, input={1}")
+    @ParameterizedTest(name = "{0}")
     @CsvSource({
-            "some text, some text",                 // withoutLatexCommandsUnmodified
-            "'', \\sometext",                       // singleCommandWiped
-            "text, \\some text",                    // singleSpaceAfterCommandRemoved
-            "text, \\some     text",                // multipleSpacesAfterCommandRemoved
-            "\\, \\\\",                             // escapedBackslashBecomesBackslash
-            "\\some text, \\\\some text",           // escapedBackslashFollowedByTextBecomesBackslashFollowedByText
-            "\\some text\\, \\\\some text\\\\",     // escapedBackslashKept
-            "some_text, some\\_text"                // escapedUnderscoreReplaces
+            "withoutLatexCommandsUnmodified, some text, some text",
+            "singleCommandWiped, '', \\sometext",
+            "singleSpaceAfterCommandRemoved, text, \\some text",
+            "multipleSpacesAfterCommandRemoved, text, \\some     text",
+            "escapedBackslashBecomesBackslash, \\, \\\\",
+            "escapedBackslashFollowedByTextBecomesBackslashFollowedByText, \\some text, \\\\some text",
+            "escapedBackslashKept, \\some text\\, \\\\some text\\\\",
+            "escapedUnderscoreReplaces, some_text, some\\_text"
     })
     public void formatterTest(String expected, String input) {
         assertEquals(expected, formatter.format(input));

--- a/src/test/resources/tinylog-test.properties
+++ b/src/test/resources/tinylog-test.properties
@@ -4,3 +4,5 @@ writer = console
 #level@org.jabref.model.entry.BibEntry = debug
 #level@org.jabref.logic.importer.fetcher.ResearchGate = trace
 #level@org.jabref.logic.importer.fetcher.DoiFetcher = trace
+
+level@org.jabref.logic.bst.BstPreviewLayout = trace


### PR DESCRIPTION
Fixes #11338 

Open points

- [ ] Let SnuggleTeX NOT fail on error, but "just" continue (we can accept lost characters)
- [ ] Adapt tests to check for `.body().text()` and not for complete HTML
- [ ] Currently, `NBSP` appears when `~` is rendered. Strange.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
