### PR TITLE
Create devdocs as .pdf and .html

### DIFF
--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -6,11 +6,15 @@ on:
       - main
     paths:
       - 'docs/**.md'
-      - .github/workflows/convert-docs-to-pdf.yml
+      - '.github/workflows/convert-docs-to-pdf.yml'
   pull_request:
     paths:
       - 'docs/**.md'
-      - .github/workflows/convert-docs-to-pdf.yml
+      - '.github/workflows/convert-docs-to-pdf.yml'
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -196,7 +196,7 @@ jobs:
         path: pdfs/
 
     - name: Publish
-      if: github.head_ref == 'main'
+      if: github.ref == 'main' || github.head_ref == 'publish-devdocs-as-pdf'
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -153,8 +153,9 @@ jobs:
           xstring
     - name: Merge PDFs into one PDF file
       run: |
-        # Currently, filenames with % cannot be handled; thus we filter it
-        (echo pdfs/index.pdf; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | grep -v '%' | sort) | paste -sd, - > filelist.txt
+        # Currently, filenames with % and # cannot be handled; thus we filter it
+        (echo pdfs/index.pdf; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | grep -v '%' | grep -v '#' | sort) | paste -sd, - > filelist.txt
+        cat filelist.txt
 
         cat <<EOF > jabref-devdocs.tex
         \documentclass[a4paper]{article}

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -45,7 +45,7 @@ jobs:
             const fs = require('fs');
             const puppeteer = require('puppeteer');
             (async () => {
-            const browser = await puppeteer.launch({ headless: "new" });
+            const browser = await puppeteer.launch({ headless: "new", args: ["--no-sandbox", "--disable-setuid-sandbox"] })
             const files = fs.readdirSync('publish').filter(f => f.endsWith('.html'));
             for (const file of files) {
                 const page = await browser.newPage();
@@ -65,7 +65,7 @@ jobs:
             const puppeteer = require('puppeteer');
 
             (async () => {
-            const browser = await puppeteer.launch({ headless: "new" });
+            const browser = await puppeteer.launch({ headless: "new", args: ["--no-sandbox", "--disable-setuid-sandbox"] })
             const page = await browser.newPage();
 
             // Sort filenames alphabetically for consistent order

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -169,13 +169,12 @@ jobs:
         \begin{document}
 
         \renewcommand{\do}[1]{%
-        \StrBehind{#1}{/}[\filename]%
-        \StrBefore{\filename}{.pdf}[\bookmarktitle]%
-        \pdfbookmark[1]{\bookmarktitle}{\bookmarktitle}%
-        \clearpage
-        \phantomsection
-        \addcontentsline{toc}{section}{\bookmarktitle}
-        \includepdf[pages=-]{#1}%
+          \StrBehind{#1}{/}[\filename]%
+          \StrBefore{\filename}{.pdf}[\bookmarktitle]%
+          \clearpage
+          \phantomsection
+          \addcontentsline{toc}{section}{\bookmarktitle}
+          \includepdf[pages=-]{#1}%
         }
 
         \CatchFileDef{\filelist}{filelist.txt}{}

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -141,6 +141,7 @@ jobs:
           lm
           ltxcmds
           metafont
+          mfware
           pdfescape
           pdflscape
           pdfpages

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -25,77 +25,64 @@ jobs:
 
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with:
-        packages: pandoc
+        packages: poppler-utils xmlstarlet
         version: 1.0
 
     - run: npm install puppeteer
 
-    - name: Convert Markdown to HTML
+    - name: Crawl URLs from sitemap
       run: |
-        mkdir -p publish
-        find docs -type f -name '*.md' ! -iname 'README.md' | while read file; do
-          filename=$(basename "${file%.*}")
-          pandoc "$file" -o "publish/$filename.html"
-        done
+        mkdir urls
+        curl -s https://devdocs.jabref.org/sitemap.xml |
+            xmlstarlet sel -t -m '//url/loc' -v . -n > urls/list.txt
+        sed -i 's|^/|https://devdocs.jabref.org/|' urls/list.txt
+        cat urls/list.txt
 
-    - name: Convert HTML to PDF using Puppeteer
+    - name: Download pages as PDFs
       run: |
-        # source: https://stackoverflow.com/a/78897319/873282
+        mkdir pdfs
         node <<'EOF'
-            const fs = require('fs');
-            const puppeteer = require('puppeteer');
-            (async () => {
-            const browser = await puppeteer.launch({ headless: "new", args: ["--no-sandbox", "--disable-setuid-sandbox"] })
-            const files = fs.readdirSync('publish').filter(f => f.endsWith('.html'));
-            for (const file of files) {
-                const page = await browser.newPage();
-                await page.goto(`file://${process.cwd()}/publish/${file}`, { waitUntil: 'networkidle2' });
-                await page.pdf({ path: `publish/${file.replace('.html', '.pdf')}` });
-            }
-            await browser.close();
-            })();
-        EOF
-
-    - name: Merge all HTMLs into single PDF
-      run: |
-        node <<'EOF'
-            const fs = require('fs');
-            const puppeteer = require('puppeteer');
-
-            (async () => {
-            const browser = await puppeteer.launch({ headless: "new", args: ["--no-sandbox", "--disable-setuid-sandbox"] })
+        const fs = require('fs');
+        const puppeteer = require('puppeteer');
+        (async () => {
+            const urls = fs.readFileSync('urls/list.txt', 'utf-8')
+                            .split('\n')
+                            .filter(Boolean);
+            const browser = await puppeteer.launch({
+            headless: "new",
+            args: ["--no-sandbox", "--disable-setuid-sandbox"]
+            });
             const page = await browser.newPage();
-
-            // Sort filenames alphabetically for consistent order
-            const files = fs.readdirSync('publish').filter(f => f.endsWith('.html')).sort();
-
-            let combinedHTML = '';
-            for (const file of files) {
-                const html = fs.readFileSync(`publish/${file}`, 'utf8');
-                combinedHTML += `\n<div style="page-break-after: always;">${html}</div>\n`;
+            for (let i = 0; i < urls.length; i++) {
+            const url = urls[i];
+            const filename = `pdfs/page${String(i + 1).padStart(3, '0')}.pdf`;
+            console.log(`Rendering ${url} → ${filename}`);
+            await page.goto(url, { waitUntil: 'networkidle2' });
+            await page.pdf({
+                path: filename,
+                format: 'A4',
+                printBackground: true
+            });
             }
-
-            const tempPath = 'publish/_combined.html';
-            fs.writeFileSync(tempPath, `<html><body>${combinedHTML}</body></html>`);
-
-            await page.goto(`file://${process.cwd()}/${tempPath}`, { waitUntil: 'networkidle2' });
-            await page.pdf({ path: 'publish/jabref-devdocs.pdf' });
-
             await browser.close();
         })();
         EOF
 
+    - name: Merge PDFs into one file
+      run: |
+        pdfunite pdfs/*.pdf pdfs/jabref-docs-complete.pdf
+
     - uses: actions/upload-artifact@v4
       with:
         name: docs
-        path: publish/
+        path: pdfs/
 
     - name: Publish
       if: github.head_ref == 'main'
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./publish
+        publish_dir: ./pdfs
         publish_branch: devdocs
         force_orphan: true
         enable_jekyll: false

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -43,19 +43,48 @@ jobs:
       run: |
         # source: https://stackoverflow.com/a/78897319/873282
         node <<'EOF'
-        const fs = require('fs');
-        const puppeteer = require('puppeteer');
-        (async () => {
-          const browser = await puppeteer.launch({ headless: "new" });
-          const files = fs.readdirSync('publish').filter(f => f.endsWith('.html'));
-          for (const file of files) {
+            const fs = require('fs');
+            const puppeteer = require('puppeteer');
+            (async () => {
+            const browser = await puppeteer.launch({ headless: "new" });
+            const files = fs.readdirSync('publish').filter(f => f.endsWith('.html'));
+            for (const file of files) {
+                const page = await browser.newPage();
+                await page.goto(`file://${process.cwd()}/publish/${file}`, {
+                waitUntil: 'networkidle2'
+                });
+                await page.pdf({ path: `publish/${file.replace('.html', '.pdf')}` });
+            }
+            await browser.close();
+            })();
+        EOF
+
+    - name: Merge all HTMLs into single PDF
+      run: |
+        node <<'EOF'
+            const fs = require('fs');
+            const puppeteer = require('puppeteer');
+
+            (async () => {
+            const browser = await puppeteer.launch({ headless: "new" });
             const page = await browser.newPage();
-            await page.goto(`file://${process.cwd()}/publish/${file}`, {
-              waitUntil: 'networkidle2'
-            });
-            await page.pdf({ path: `publish/${file.replace('.html', '.pdf')}` });
-          }
-          await browser.close();
+
+            // Sort filenames alphabetically for consistent order
+            const files = fs.readdirSync('publish').filter(f => f.endsWith('.html')).sort();
+
+            let combinedHTML = '';
+            for (const file of files) {
+                const html = fs.readFileSync(`publish/${file}`, 'utf8');
+                combinedHTML += `\n<div style="page-break-after: always;">${html}</div>\n`;
+            }
+
+            const tempPath = 'publish/_combined.html';
+            fs.writeFileSync(tempPath, `<html><body>${combinedHTML}</body></html>`);
+
+            await page.goto(`file://${process.cwd()}/${tempPath}`, { waitUntil: 'networkidle2' });
+            await page.pdf({ path: 'publish/jabref-devdocs.pdf' });
+
+            await browser.close();
         })();
         EOF
 

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -62,9 +62,6 @@ jobs:
         echo "=== list.txt (final full URLs) ==="
         cat urls/list.txt
 
-        echo https://devdocs.jabref.org/index.html > urls/list.txt
-        echo https://devdocs.jabref.org/code-howtos/remote-storage-sql.html >> urls/list.txt
-
     - name: Download pages as PDFs
       run: |
         mkdir pdfs

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -136,7 +136,7 @@ jobs:
           latexconfig
           lm
           ltxcmds
-          mf
+          metafont
           pdfescape
           pdflscape
           pdfpages

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -153,6 +153,7 @@ jobs:
           xstring
     - name: Merge PDFs into one PDF file
       run: |
+        # Currently, filenames with % cannot be handled; thus we filter it
         (echo pdfs/index.pdf; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | grep -v '%' | sort) | paste -sd, - > filelist.txt
 
         cat <<EOF > jabref-devdocs.tex

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -7,8 +7,9 @@ on:
     paths:
       - '.github/workflows/convert-docs-to-pdf.yml'
   pull_request:
-    paths:
-      - '.github/workflows/convert-docs-to-pdf.yml'
+     # always build - therefore disabled
+#    paths:
+#      - '.github/workflows/convert-docs-to-pdf.yml'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -153,7 +153,7 @@ jobs:
           xstring
     - name: Merge PDFs into one PDF file
       run: |
-        (echo pdfs/index.pdf; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | sort) | paste -sd, - > filelist.txt
+        (echo pdfs/index.pdf; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | grep -v '%' | sort) | paste -sd, - > filelist.txt
 
         cat <<EOF > jabref-devdocs.tex
         \documentclass[a4paper]{article}

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -79,7 +79,7 @@ jobs:
               const url = urls[i];
               const urlPath = new URL(url).pathname.replace(/^\/|\/$/g, '');
               const safeName = urlPath.replace(/\//g, '--') || 'index';
-              const basePath = `pdfs/${safeName}`;
+              const basePath = `pdfs/${safeName.replace(/\.html$/, '')}`;
 
               console.log(`Rendering ${url} → ${basePath}.html/pdf`);
 
@@ -102,9 +102,42 @@ jobs:
          })();
         EOF
 
-    - name: Merge PDFs into one file
+    - name: Install TeX Live
+      uses: zauguin/install-texlive@v4
+      with:
+        packages: >
+          latex latex-bin pdfpages hyperref catchfile xstring etoolbox
+
+    - name: Merge PDFs into one PDF file
       run: |
-        pdfunite pdfs/*.pdf pdfs/jabref-docs-complete.pdf
+        (echo pdfs/index.pdf; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | sort) > filelist.txt
+
+        cat <<EOF > jabref-devdocs.tex
+        \documentclass[a4paper]{article}
+        \usepackage{pdfpages}
+        \usepackage[bookmarks=true]{hyperref}
+        \usepackage{catchfile}
+        \usepackage{xstring}
+        \usepackage{etoolbox}
+
+        \newcommand{\includepdfwithbookmark}[1]{%
+        \StrBehind{#1}{/}[\filename]%
+        \StrBefore{\filename}{.pdf}[\bookmarktitle]%
+        \pdfbookmark[1]{\bookmarktitle}{\bookmarktitle}%
+        \includepdf[pages=-]{#1}%
+        }
+
+        \CatchFileDef{\filelist}{filelist.txt}{}
+
+        \renewcommand*{\do}[1]{\includepdfwithbookmark{##1}}
+        \docsvlist{\filelist}
+
+        \end{document}
+        EOF
+
+        pdflatex -shell-escape jabref-devdocs
+        pdflatex -shell-escape jabref-devdocs
+        mv jabref-devdocs.pdf pdfs/
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -179,6 +179,7 @@ jobs:
 
         \CatchFileDef{\filelist}{filelist.txt}{}
 
+        \pdfbookmark[1]{Contents}{Contents}%
         \tableofcontents
 
         \expandafter\docsvlist\expandafter{\filelist}

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**.md'
       - '.github/workflows/convert-docs-to-pdf.yml'
   pull_request:
     paths:
-      - 'docs/**.md'
       - '.github/workflows/convert-docs-to-pdf.yml'
 
 concurrency:

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -22,7 +22,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '22'
-        cache: 'npm'
 
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with:

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -82,7 +82,7 @@ jobs:
             for (let i = 0; i < urls.length; i++) {
               const url = urls[i];
               const urlPath = new URL(url).pathname.replace(/^\/|\/$/g, '');
-              const safeName = urlPath.replace(/\//g, '--') || 'index';
+              const safeName = decodeURIComponent(urlPath).replace(/\//g, '--') || 'index';
               const basePath = `pdfs/${safeName.replace(/\.html$/, '')}`;
 
               console.log(`Rendering ${url} → ${basePath}.html/pdf`);

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -32,6 +32,7 @@ jobs:
 
     - name: Crawl URLs from sitemap
       run: |
+        set -e
         mkdir urls
         curl -s https://devdocs.jabref.org/sitemap.xml |
             xmlstarlet sel -t -m '//url/loc' -v . -n > urls/list.txt

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Convert Markdown to HTML
       run: |
         mkdir -p publish
-        for file in docs/*.md; do
-          filename=$(basename "$file" .md)
+        find docs -type f -name '*.md' ! -iname 'README.md' | while read file; do
+          filename=$(basename "${file%.*}")
           pandoc "$file" -o "publish/$filename.html"
         done
 
@@ -49,9 +49,7 @@ jobs:
             const files = fs.readdirSync('publish').filter(f => f.endsWith('.html'));
             for (const file of files) {
                 const page = await browser.newPage();
-                await page.goto(`file://${process.cwd()}/publish/${file}`, {
-                waitUntil: 'networkidle2'
-                });
+                await page.goto(`file://${process.cwd()}/publish/${file}`, { waitUntil: 'networkidle2' });
                 await page.pdf({ path: `publish/${file.replace('.html', '.pdf')}` });
             }
             await browser.close();

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -118,22 +118,28 @@ jobs:
         cat <<EOF > jabref-devdocs.tex
         \documentclass[a4paper]{article}
         \usepackage{pdfpages}
-        \usepackage[bookmarks=true]{hyperref}
+        \usepackage[bookmarks=true,linktoc=all]{hyperref}
         \usepackage{catchfile}
         \usepackage{xstring}
         \usepackage{etoolbox}
 
-        \newcommand{\includepdfwithbookmark}[1]{%
+        \begin{document}
+
+        \renewcommand{\do}[1]{%
         \StrBehind{#1}{/}[\filename]%
         \StrBefore{\filename}{.pdf}[\bookmarktitle]%
         \pdfbookmark[1]{\bookmarktitle}{\bookmarktitle}%
+        \clearpage
+        \phantomsection
+        \addcontentsline{toc}{section}{\bookmarktitle}
         \includepdf[pages=-]{#1}%
         }
 
         \CatchFileDef{\filelist}{filelist.txt}{}
 
-        \renewcommand*{\do}[1]{\includepdfwithbookmark{##1}}
-        \docsvlist{\filelist}
+        \tableofcontents
+
+        \expandafter\docsvlist\expandafter{\filelist}
 
         \end{document}
         EOF

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -64,28 +64,42 @@ jobs:
         node <<'EOF'
         const fs = require('fs');
         const puppeteer = require('puppeteer');
+
         (async () => {
             const urls = fs.readFileSync('urls/list.txt', 'utf-8')
-                            .split('\n')
-                            .filter(Boolean);
+                           .split('\n')
+                           .filter(Boolean);
+
             const browser = await puppeteer.launch({
-            headless: "new",
-            args: ["--no-sandbox", "--disable-setuid-sandbox"]
+              headless: "new",
+              args: ["--no-sandbox", "--disable-setuid-sandbox"]
             });
-            const page = await browser.newPage();
+
             for (let i = 0; i < urls.length; i++) {
-            const url = urls[i];
-            const filename = `pdfs/page${String(i + 1).padStart(3, '0')}.pdf`;
-            console.log(`Rendering ${url} → ${filename}`);
-            await page.goto(url, { waitUntil: 'networkidle2' });
-            await page.pdf({
-                path: filename,
+              const url = urls[i];
+              const urlPath = new URL(url).pathname.replace(/^\/|\/$/g, '');
+              const safeName = urlPath.replace(/\//g, '--') || 'index';
+              const basePath = `pdfs/${safeName}`;
+
+              console.log(`Rendering ${url} → ${basePath}.html/pdf`);
+
+              const page = await browser.newPage();
+              await page.goto(url, { waitUntil: 'networkidle2' });
+
+              const content = await page.content();
+              fs.writeFileSync(`${basePath}.html`, content);
+
+              await page.pdf({
+                path: `${basePath}.pdf`,
                 format: 'A4',
                 printBackground: true
-            });
+              });
+
+              await page.close();
             }
+
             await browser.close();
-        })();
+         })();
         EOF
 
     - name: Merge PDFs into one file

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -33,10 +33,26 @@ jobs:
     - name: Crawl URLs from sitemap
       run: |
         set -e
-        mkdir urls
-        curl -s https://devdocs.jabref.org/sitemap.xml |
-            xmlstarlet sel -t -m '//url/loc' -v . -n > urls/list.txt
-        sed -i 's|^/|https://devdocs.jabref.org/|' urls/list.txt
+
+        mkdir -p urls
+
+        # Debug: Tool-Versionen prüfen
+        curl --version
+        xmlstarlet --version
+
+        # 1. Sitemap herunterladen
+        curl -s https://devdocs.jabref.org/sitemap.xml > urls/sitemap.xml
+        echo "=== sitemap.xml ==="
+        cat urls/sitemap.xml
+
+        # 2. URLs extrahieren
+        xmlstarlet sel -t -m '//url/loc' -v . -n urls/sitemap.xml > urls/raw.txt
+        echo "=== raw.txt (extrahierte loc-Tags) ==="
+        cat urls/raw.txt
+
+        # 3. Absolute URLs erzeugen (falls sie mit / beginnen)
+        sed 's|^/|https://devdocs.jabref.org/|' urls/raw.txt > urls/list.txt
+        echo "=== list.txt (bereinigte URLs) ==="
         cat urls/list.txt
 
     - name: Download pages as PDFs

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -109,8 +109,45 @@ jobs:
       uses: zauguin/install-texlive@v4
       with:
         packages: >
-          latex latex-bin pdfpages hyperref catchfile xstring etoolbox
-
+          bigintcalc
+          bitset
+          catchfile
+          cm
+          epstopdf-pkg
+          eso-pic
+          etexcmds
+          etoolbox
+          gettitlestring
+          graphics
+          graphics-cfg
+          graphics-def
+          hycolor
+          hyperref
+          iftex
+          infwarerr
+          intcalc
+          kvdefinekeys
+          kvoptions
+          kvsetkeys
+          l3backend
+          latex
+          latex-bin
+          latex-fonts
+          latexconfig
+          lm
+          ltxcmds
+          pdfescape
+          pdflscape
+          pdfpages
+          pdftexcmds
+          refcount
+          rerunfilecheck
+          stringenc
+          tools
+          uniquecounter
+          url
+          xcolor
+          xstring
     - name: Merge PDFs into one PDF file
       run: |
         (echo pdfs/index.pdf; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | sort) | paste -sd, - > filelist.txt

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -171,7 +171,7 @@ jobs:
           \clearpage
           \phantomsection
           \addcontentsline{toc}{section}{\bookmarktitle}
-          \includepdf[pages=-]{#1}%
+          \includepdf[pages=-]{\detokenize{#1}}%
         }
 
         \CatchFileDef{\filelist}{filelist.txt}{}

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -36,23 +36,26 @@ jobs:
 
         mkdir -p urls
 
-        # Debug: Tool-Versionen prüfen
+        # Debug: Check tool versions
         curl --version
         xmlstarlet --version
 
-        # 1. Sitemap herunterladen
+        # Step 1: Download sitemap
         curl -s https://devdocs.jabref.org/sitemap.xml > urls/sitemap.xml
         echo "=== sitemap.xml ==="
         cat urls/sitemap.xml
 
-        # 2. URLs extrahieren
-        xmlstarlet sel -t -m '//url/loc' -v . -n urls/sitemap.xml > urls/raw.txt
-        echo "=== raw.txt (extrahierte loc-Tags) ==="
+        # Step 2: Extract <loc> entries using xmlstarlet
+        xmlstarlet sel \
+          -N x="http://www.sitemaps.org/schemas/sitemap/0.9" \
+          -t -m '//x:url/x:loc' -v . -n urls/sitemap.xml \
+          > urls/raw.txt
+        echo "=== raw.txt (raw <loc> entries) ==="
         cat urls/raw.txt
 
-        # 3. Absolute URLs erzeugen (falls sie mit / beginnen)
+        # Step 3: Ensure full URLs (prefix relative paths)
         sed 's|^/|https://devdocs.jabref.org/|' urls/raw.txt > urls/list.txt
-        echo "=== list.txt (bereinigte URLs) ==="
+        echo "=== list.txt (final full URLs) ==="
         cat urls/list.txt
 
     - name: Download pages as PDFs

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -113,7 +113,7 @@ jobs:
 
     - name: Merge PDFs into one PDF file
       run: |
-        (echo -n "pdfs/index.pdf"; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | sort | sed 's/^/, /') > filelist.txt
+        (echo pdfs/index.pdf; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | sort) | paste -sd, - > filelist.txt
 
         cat <<EOF > jabref-devdocs.tex
         \documentclass[a4paper]{article}

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -1,0 +1,75 @@
+name: Convert DevDocs to PDF
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**.md'
+      - .github/workflows/convert-docs-to-pdf.yml
+  pull_request:
+    paths:
+      - 'docs/**.md'
+      - .github/workflows/convert-docs-to-pdf.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: pandoc
+        version: 1.0
+
+    - run: npm install puppeteer
+
+    - name: Convert Markdown to HTML
+      run: |
+        mkdir -p publish
+        for file in docs/*.md; do
+          filename=$(basename "$file" .md)
+          pandoc "$file" -o "publish/$filename.html"
+        done
+
+    - name: Convert HTML to PDF using Puppeteer
+      run: |
+        # source: https://stackoverflow.com/a/78897319/873282
+        node <<'EOF'
+        const fs = require('fs');
+        const puppeteer = require('puppeteer');
+        (async () => {
+          const browser = await puppeteer.launch({ headless: "new" });
+          const files = fs.readdirSync('publish').filter(f => f.endsWith('.html'));
+          for (const file of files) {
+            const page = await browser.newPage();
+            await page.goto(`file://${process.cwd()}/publish/${file}`, {
+              waitUntil: 'networkidle2'
+            });
+            await page.pdf({ path: `publish/${file.replace('.html', '.pdf')}` });
+          }
+          await browser.close();
+        })();
+        EOF
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: docs
+        path: publish/
+
+    - name: Publish
+      if: github.head_ref == 'main'
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./publish
+        publish_branch: devdocs
+        force_orphan: true
+        enable_jekyll: false

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -136,6 +136,7 @@ jobs:
           latexconfig
           lm
           ltxcmds
+          mf
           pdfescape
           pdflscape
           pdfpages

--- a/.github/workflows/convert-docs-to-pdf.yml
+++ b/.github/workflows/convert-docs-to-pdf.yml
@@ -58,6 +58,9 @@ jobs:
         echo "=== list.txt (final full URLs) ==="
         cat urls/list.txt
 
+        echo https://devdocs.jabref.org/index.html > urls/list.txt
+        echo https://devdocs.jabref.org/code-howtos/remote-storage-sql.html >> urls/list.txt
+
     - name: Download pages as PDFs
       run: |
         mkdir pdfs
@@ -110,7 +113,7 @@ jobs:
 
     - name: Merge PDFs into one PDF file
       run: |
-        (echo pdfs/index.pdf; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | sort) > filelist.txt
+        (echo -n "pdfs/index.pdf"; find pdfs/ -type f -name '*.pdf' ! -name 'index.pdf' | sort | sed 's/^/, /') > filelist.txt
 
         cat <<EOF > jabref-devdocs.tex
         \documentclass[a4paper]{article}


### PR DESCRIPTION
Trying to generate pdf files out of devdocs - also supporting mermaid js

Idea from https://stackoverflow.com/a/78897319/873282

Refs https://github.com/just-the-docs/just-the-docs/issues/1638

Fully rendered PDF available at https://jabref.github.io/jabref-koppor/jabref-devdocs.pdf

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
