### PR TITLE
Test case FilteredList modified by TabObservableList.reorder

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -93,10 +93,7 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
 
     private final FileHistoryMenu fileHistory;
 
-    @SuppressWarnings({"FieldCanBeLocal"})
-    private FilteredList<Tab> filteredTabs;
-    @SuppressWarnings({"FieldCanBeLocal"})
-    private EasyObservableList<BibDatabaseContext> openDatabaseList;
+    @SuppressWarnings({"FieldCanBeLocal"}) private EasyObservableList<BibDatabaseContext> openDatabaseList;
 
     private final Stage mainStage;
     private final StateManager stateManager;
@@ -377,16 +374,12 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
     }
 
     private void initBindings() {
-        filteredTabs = new FilteredList<>(tabbedPane.getTabs(), tab -> {
-            System.out.println(tab);
-            return tab instanceof LibraryTab;
-        });
+        // Bind global state
+        FilteredList<Tab> filteredTabs = new FilteredList<>(tabbedPane.getTabs());
+        filteredTabs.setPredicate(LibraryTab.class::isInstance);
 
         // This variable cannot be inlined, since otherwise the list created by EasyBind is being garbage collected
-        openDatabaseList = EasyBind.map(filteredTabs, tab -> {
-            System.out.println(tab);
-            return ((LibraryTab) tab).getBibDatabaseContext();
-        });
+        openDatabaseList = EasyBind.map(filteredTabs, tab -> ((LibraryTab) tab).getBibDatabaseContext());
         EasyBind.bindContent(stateManager.getOpenDatabases(), openDatabaseList);
 
         // the binding for stateManager.activeDatabaseProperty() is at org.jabref.gui.LibraryTab.onDatabaseLoadingSucceed

--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -93,7 +93,10 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
 
     private final FileHistoryMenu fileHistory;
 
-    @SuppressWarnings({"FieldCanBeLocal"}) private EasyObservableList<BibDatabaseContext> openDatabaseList;
+    @SuppressWarnings({"FieldCanBeLocal"})
+    private FilteredList<Tab> filteredTabs;
+    @SuppressWarnings({"FieldCanBeLocal"})
+    private EasyObservableList<BibDatabaseContext> openDatabaseList;
 
     private final Stage mainStage;
     private final StateManager stateManager;
@@ -374,12 +377,16 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
     }
 
     private void initBindings() {
-        // Bind global state
-        FilteredList<Tab> filteredTabs = new FilteredList<>(tabbedPane.getTabs());
-        filteredTabs.setPredicate(LibraryTab.class::isInstance);
+        filteredTabs = new FilteredList<>(tabbedPane.getTabs(), tab -> {
+            System.out.println(tab);
+            return tab instanceof LibraryTab;
+        });
 
         // This variable cannot be inlined, since otherwise the list created by EasyBind is being garbage collected
-        openDatabaseList = EasyBind.map(filteredTabs, tab -> ((LibraryTab) tab).getBibDatabaseContext());
+        openDatabaseList = EasyBind.map(filteredTabs, tab -> {
+            System.out.println(tab);
+            return ((LibraryTab) tab).getBibDatabaseContext();
+        });
         EasyBind.bindContent(stateManager.getOpenDatabases(), openDatabaseList);
 
         // the binding for stateManager.activeDatabaseProperty() is at org.jabref.gui.LibraryTab.onDatabaseLoadingSucceed

--- a/jabgui/src/test/java/org/jabref/gui/javafx/TabObservableListFilteredTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/javafx/TabObservableListFilteredTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 public class TabObservableListFilteredTest {
 
     @Test
-    public void testFilteredListDetectsPermutation() {
+    public void filteredListDetectsPermutation() {
         Tab lib1 = new Tab("lib1");
         Tab lib2 = new Tab("lib2");
         Tab other = new Tab("other");
@@ -32,7 +32,7 @@ public class TabObservableListFilteredTest {
 
         base.reorder(lib1, other);
 
-        assertNotEquals(other, filtered.get(0)); // This should not fail
+        assertNotEquals(other, filtered.getFirst()); // This should not fail
 
         assertEquals(List.of(lib2, lib1), filtered);
     }

--- a/jabgui/src/test/java/org/jabref/gui/javafx/TabObservableListFilteredTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/javafx/TabObservableListFilteredTest.java
@@ -1,0 +1,39 @@
+package org.jabref.gui.javafx;
+
+import java.util.List;
+
+import javafx.collections.transformation.FilteredList;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+
+import com.sun.javafx.scene.control.TabObservableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@ExtendWith(ApplicationExtension.class)
+public class TabObservableListFilteredTest {
+
+    @Test
+    public void testFilteredListDetectsPermutation() {
+        Tab lib1 = new Tab("lib1");
+        Tab lib2 = new Tab("lib2");
+        Tab other = new Tab("other");
+
+        TabPane tabPane = new TabPane(lib1, other, lib2);
+        TabObservableList<Tab> base = (TabObservableList) tabPane.getTabs();
+
+        FilteredList<Tab> filtered = new FilteredList<>(base, tab -> tab.getText().startsWith("lib"));
+
+        assertEquals(List.of(lib1, lib2), filtered);
+
+        base.reorder(lib1, other);
+
+        assertNotEquals(other, filtered.get(0)); // This should not fail
+
+        assertEquals(List.of(lib2, lib1), filtered);
+    }
+}


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13245; Refs https://github.com/JabRef/jabref/issues/12921

Public issue: [JDK-8359020 : TabObservableList.reorder changes content of filtered list](https://bugs.java.com/bugdatabase/view_bug?bug_id=JDK-8359020)

<details>
Submitted a JavaFX error report - internal review ID : 9078592 (refs https://github.com/JabRef/jabref/pull/13244#issuecomment-2940155513)
</details>

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
