### PR TITLE
Enable use of liberica jdk full

### DIFF
--- a/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradlex.javamodule.dependencies.JavaModuleDependenciesExtension
 import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesOrderingCheck
 
 plugins {
@@ -8,6 +9,25 @@ plugins {
 
 // module-info entry order not checked
 tasks.withType<ModuleDirectivesOrderingCheck> { enabled = false }
+
+// Opt-in (-PuseLibericaJdkFull=true): consume the JavaFX bundled in the JDK (e.g. Liberica Full) instead of Maven.
+// The java-module-dependencies plugin maps each 'requires javafx.*' to an 'org.openjfx:javafx-*' dependency.
+// Removing those module-name -> GA mappings makes the plugin add no dependency for those modules, so they are
+// resolved from the JDK's system module path. (The plugin only logs a [WARN] for an unmapped 'requires'.)
+// The JavaFX version pin (versions/build.gradle.kts), the platform-variant patches and the per-module
+// opens/exports patches below then have nothing to act on and stay inert; the runtime opens/exports they
+// provided are re-applied as JVM args in jabgui/build.gradle.kts.
+val useLibericaJdkFull = providers.gradleProperty("useLibericaJdkFull").map { it != "false" }.getOrElse(false)
+if (useLibericaJdkFull) {
+    val javafxModuleNames = setOf(
+        "javafx.base", "javafx.controls", "javafx.fxml",
+        "javafx.graphics", "javafx.media", "javafx.swing", "javafx.web"
+    )
+    val javaModuleDependencies = extensions.getByType(JavaModuleDependenciesExtension::class.java)
+    javaModuleDependencies.moduleNameToGA.set(
+        javaModuleDependencies.moduleNameToGA.get().filterKeys { it !in javafxModuleNames }
+    )
+}
 
 jvmDependencyConflicts {
     consistentResolution {

--- a/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradlex.javamodule.dependencies.JavaModuleDependenciesExtension
 import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesOrderingCheck
+import org.jabref.gradle.useLibericaJdkFull
 
 plugins {
     id("org.gradlex.extra-java-module-info")
@@ -16,8 +17,7 @@ tasks.withType<ModuleDirectivesOrderingCheck> { enabled = false }
 // resolved from the JDK's system module path. (The plugin only logs a [WARN] for an unmapped 'requires'.)
 // The JavaFX version pin (versions/build.gradle.kts), the platform-variant patches and the per-module
 // opens/exports patches below then have nothing to act on and stay inert; the runtime opens/exports they
-// provided are re-applied as JVM args in jabgui/build.gradle.kts.
-val useLibericaJdkFull = providers.gradleProperty("useLibericaJdkFull").map { it != "false" }.getOrElse(false)
+// provided are re-applied as JVM args in jabgui/build.gradle.kts. (Flag: org.jabref.gradle.JavaFxBundling)
 if (useLibericaJdkFull) {
     val javafxModuleNames = setOf(
         "javafx.base", "javafx.controls", "javafx.fxml",

--- a/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
@@ -1,4 +1,3 @@
-import org.gradlex.javamodule.dependencies.JavaModuleDependenciesExtension
 import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesOrderingCheck
 import org.jabref.gradle.useLibericaJdkFull
 
@@ -12,21 +11,19 @@ plugins {
 tasks.withType<ModuleDirectivesOrderingCheck> { enabled = false }
 
 // Opt-in (-PuseLibericaJdkFull=true): consume the JavaFX bundled in the JDK (e.g. Liberica Full) instead of Maven.
-// The java-module-dependencies plugin maps each 'requires javafx.*' to an 'org.openjfx:javafx-*' dependency.
-// Removing those module-name -> GA mappings makes the plugin add no dependency for those modules, so they are
-// resolved from the JDK's system module path. (The plugin only logs a [WARN] for an unmapped 'requires'.)
-// The JavaFX version pin (versions/build.gradle.kts), the platform-variant patches and the per-module
-// opens/exports patches below then have nothing to act on and stay inert; the runtime opens/exports they
-// provided are re-applied as JVM args in jabgui/build.gradle.kts. (Flag: org.jabref.gradle.JavaFxBundling)
+// The java-module-dependencies plugin maps each 'requires javafx.*' to an 'org.openjfx:javafx-*' dependency; we drop
+// those from every configuration via an exclude, so 'requires javafx.*' is satisfied by the JDK's own system modules.
+// The JavaFX version pin (versions/build.gradle.kts), the platform-variant patches and the per-module opens/exports
+// patches below then have nothing to act on and stay inert; the runtime opens/exports they provided are re-applied as
+// JVM args in jabgui/build.gradle.kts. (Flag: org.jabref.gradle.JavaFxBundling)
 if (useLibericaJdkFull) {
-    val javafxModuleNames = setOf(
-        "javafx.base", "javafx.controls", "javafx.fxml",
-        "javafx.graphics", "javafx.media", "javafx.swing", "javafx.web"
-    )
-    val javaModuleDependencies = extensions.getByType(JavaModuleDependenciesExtension::class.java)
-    javaModuleDependencies.moduleNameToGA.set(
-        javaModuleDependencies.moduleNameToGA.get().filterKeys { it !in javafxModuleNames }
-    )
+    // The exclude is applied lazily at resolution time and, crucially, leaves moduleNameToGA untouched: eagerly reading
+    // and replacing that map (moduleNameToGA.get()/.set()) snapshots it before the plugin finishes contributing the
+    // project's other module-name -> GA mappings, silently discarding entries such as 'unirest.modules.gson' and thereby
+    // breaking transitive versions for deps only pinned via that path (e.g. gson, xz).
+    configurations.all {
+        exclude(mapOf("group" to "org.openjfx"))
+    }
 }
 
 jvmDependencyConflicts {

--- a/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
@@ -2,6 +2,15 @@ plugins {
     id("java")
 }
 
+// Opt-in: build against a JDK that bundles JavaFX (e.g. BellSoft Liberica "Full").
+// When set, JabRef does NOT pull JavaFX from Maven; 'requires javafx.*' resolves
+// against the JDK's own system modules instead. See the JavaFX handling in
+// - versions/build.gradle.kts
+// - org.jabref.gradle.base.dependency-rules.gradle.kts
+// - jabgui/build.gradle.kts (runtime --add-opens/--add-exports)
+// Enable with: -PuseLibericaJdkFull (bare flag = on; pass -PuseLibericaJdkFull=false to force off)
+val useLibericaJdkFull = providers.gradleProperty("useLibericaJdkFull").map { it != "false" }.getOrElse(false)
+
 java {
     toolchain {
         // If this is updated, also update
@@ -21,9 +30,13 @@ java {
         languageVersion = JavaLanguageVersion.of(25)
         // See https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JvmVendorSpec.html for a full list
         // Temurin does not ship jmods, thus we need to use another JDK -- see https://github.com/actions/setup-java/issues/804
-        // We also need a JDK without JavaFX, because we patch JavaFX due to modularity issues
+        // We default to a JDK without JavaFX (Amazon Corretto), because we patch JavaFX (Maven) due to modularity issues.
+        // With -PuseLibericaJdkFull=true we instead use BellSoft Liberica, which ships JavaFX, and consume that bundled JavaFX.
+        // NOTE: foojay auto-provisioning resolves BellSoft to Liberica *Standard* (no JavaFX). To actually get the
+        //       bundled JavaFX, install Liberica *Full* JDK 25 locally so the toolchain detects it (and avoid having a
+        //       Standard 25 of the same vendor installed, as the toolchain query cannot distinguish the two).
         // If this is changed, binaries.yml needs to be adapted (e.g., sed'ing to another JDK)
-        vendor = JvmVendorSpec.AMAZON
+        vendor = if (useLibericaJdkFull) JvmVendorSpec.BELLSOFT else JvmVendorSpec.AMAZON
     }
 }
 

--- a/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
@@ -1,15 +1,15 @@
+import org.jabref.gradle.useLibericaJdkFull
+
 plugins {
     id("java")
 }
 
-// Opt-in: build against a JDK that bundles JavaFX (e.g. BellSoft Liberica "Full").
-// When set, JabRef does NOT pull JavaFX from Maven; 'requires javafx.*' resolves
-// against the JDK's own system modules instead. See the JavaFX handling in
+// Opt-in (-PuseLibericaJdkFull, see org.jabref.gradle.JavaFxBundling): build against a JDK that bundles
+// JavaFX (BellSoft Liberica "Full"). When set, JabRef does NOT pull JavaFX from Maven; 'requires javafx.*'
+// resolves against the JDK's own system modules instead. See also:
 // - versions/build.gradle.kts
 // - org.jabref.gradle.base.dependency-rules.gradle.kts
 // - jabgui/build.gradle.kts (runtime --add-opens/--add-exports)
-// Enable with: -PuseLibericaJdkFull (bare flag = on; pass -PuseLibericaJdkFull=false to force off)
-val useLibericaJdkFull = providers.gradleProperty("useLibericaJdkFull").map { it != "false" }.getOrElse(false)
 
 java {
     toolchain {

--- a/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
@@ -41,7 +41,12 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    // --release is incompatible with the --add-exports for JDK-bundled JavaFX system modules used on the
+    // -PuseLibericaJdkFull path (see jabgui/build.gradle.kts). The toolchain is pinned to the same Java
+    // version, so on that path we let the toolchain set the target release instead of passing --release.
+    if (!useLibericaJdkFull) {
+        options.release = 25
+    }
     // See https://docs.gradle.org/current/userguide/performance.html#a_run_the_compiler_as_a_separate_process
     options.isFork = true
 }

--- a/build-logic/src/main/kotlin/org/jabref/gradle/JavaFxBundling.kt
+++ b/build-logic/src/main/kotlin/org/jabref/gradle/JavaFxBundling.kt
@@ -1,0 +1,18 @@
+package org.jabref.gradle
+
+import org.gradle.api.Project
+
+/**
+ * `true` when the build should consume the JavaFX that ships inside a BellSoft Liberica "Full" JDK
+ * instead of resolving `org.openjfx:*` from Maven.
+ *
+ * Enable with `-PuseLibericaJdkFull` (the bare flag counts as on); pass `-PuseLibericaJdkFull=false`
+ * (e.g. in `gradle.properties`) to force it off.
+ *
+ * Consumed by:
+ * - org.jabref.gradle.feature.compile (toolchain vendor)
+ * - org.jabref.gradle.base.dependency-rules (drop JavaFX module-name -> Maven GA mappings)
+ * - jabgui/build.gradle.kts (runtime --add-opens/--add-exports)
+ */
+val Project.useLibericaJdkFull: Boolean
+    get() = providers.gradleProperty("useLibericaJdkFull").map { it != "false" }.getOrElse(false)

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -58,6 +58,20 @@ val useLibericaJdkFullJvmArgs = if (useLibericaJdkFull) listOf(
     "--add-opens", "javafx.controls/com.sun.javafx.scene.control=org.jabref,ALL-UNNAMED"
 ) else emptyList()
 
+// Compile-time counterpart of the JavaFX --add-exports above. When JavaFX is patched Maven jars, those
+// internal com.sun.javafx.* packages are exported via the metadata patches in dependency-rules; when JavaFX
+// comes from the JDK those patches are inert, so javac needs the exports too. Only the exports are required
+// at compile time (--add-opens is reflection-only and applies at runtime via the JVM args above).
+val useLibericaJdkFullCompilerArgs = if (useLibericaJdkFull) listOf(
+    "--add-exports", "javafx.base/com.sun.javafx.event=org.jabref",
+    "--add-exports", "javafx.graphics/com.sun.javafx.scene=org.jabref",
+    "--add-exports", "javafx.controls/com.sun.javafx.scene.control=org.jabref"
+) else emptyList()
+
+tasks.named<JavaCompile>("compileJava") {
+    options.compilerArgs.addAll(useLibericaJdkFullCompilerArgs)
+}
+
 application {
     mainClass= "org.jabref.Launcher"
 

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -31,10 +31,36 @@ testModuleInfo {
     runtimeOnly("com.tngtech.archunit.junit5.engine")
 }
 
+// Opt-in (-PuseLibericaJdkFull=true): JavaFX comes from the JDK (e.g. Liberica Full), not from patched Maven jars.
+// The per-module opens/exports declared in org.jabref.gradle.base.dependency-rules.gradle.kts (javafx.base,
+// javafx.fxml, javafx.graphics, javafx.controls) are then lost and must be re-applied as JVM args here.
+// Qualified opens keep their original target module; unqualified opens/exports are reproduced for the
+// JabRef application module plus ALL-UNNAMED. If a runtime InaccessibleObjectException names another reader
+// module, append it (comma-separated) to the corresponding entry.
+val useLibericaJdkFull = providers.gradleProperty("useLibericaJdkFull").map { it != "false" }.getOrElse(false)
+val useLibericaJdkFullJvmArgs = if (useLibericaJdkFull) listOf(
+    // javafx.base
+    "--add-exports", "javafx.base/com.sun.javafx.event=org.jabref,ALL-UNNAMED",
+    "--add-opens", "javafx.base/javafx.collections=org.jabref,ALL-UNNAMED",
+    "--add-opens", "javafx.base/javafx.collections.transformation=org.jabref,ALL-UNNAMED",
+    "--add-opens", "javafx.base/com.sun.javafx.beans=net.bytebuddy",
+    // javafx.fxml
+    "--add-opens", "javafx.fxml/javafx.fxml=org.jabref.jablib",
+    // javafx.graphics
+    "--add-exports", "javafx.graphics/com.sun.javafx.scene=org.jabref,ALL-UNNAMED",
+    "--add-opens", "javafx.graphics/javafx.scene=org.controlsfx.controls",
+    // javafx.controls
+    "--add-opens", "javafx.controls/javafx.scene.control=org.jabref,ALL-UNNAMED",
+    "--add-opens", "javafx.controls/javafx.scene.control.cell=org.jabref,ALL-UNNAMED",
+    "--add-opens", "javafx.controls/javafx.scene.control.skin=org.jabref,ALL-UNNAMED",
+    "--add-exports", "javafx.controls/com.sun.javafx.scene.control=org.jabref,ALL-UNNAMED",
+    "--add-opens", "javafx.controls/com.sun.javafx.scene.control=org.jabref,ALL-UNNAMED"
+) else emptyList()
+
 application {
     mainClass= "org.jabref.Launcher"
 
-    applicationDefaultJvmArgs = listOf(
+    applicationDefaultJvmArgs = useLibericaJdkFullJvmArgs + listOf(
         "--add-modules", "jdk.incubator.vector",
         "--enable-native-access=ai.djl.tokenizers,ai.djl.pytorch_engine,com.sun.jna,javafx.graphics,javafx.media,javafx.web,org.apache.lucene.core,jkeychain",
 
@@ -172,7 +198,7 @@ tasks.test {
 
         // "--add-reads", "org.mockito=java.prefs",
         // "--add-reads", "org.jabref=wiremock"
-    )
+    ) + useLibericaJdkFullJvmArgs
 
     maxParallelForks = 1
 }

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jabref.gradle.useLibericaJdkFull
+
 plugins {
     id("org.jabref.gradle.module")
     id("org.jabref.gradle.feature.shadowjar")
@@ -36,8 +38,7 @@ testModuleInfo {
 // javafx.fxml, javafx.graphics, javafx.controls) are then lost and must be re-applied as JVM args here.
 // Qualified opens keep their original target module; unqualified opens/exports are reproduced for the
 // JabRef application module plus ALL-UNNAMED. If a runtime InaccessibleObjectException names another reader
-// module, append it (comma-separated) to the corresponding entry.
-val useLibericaJdkFull = providers.gradleProperty("useLibericaJdkFull").map { it != "false" }.getOrElse(false)
+// module, append it (comma-separated) to the corresponding entry. (Flag: org.jabref.gradle.JavaFxBundling)
 val useLibericaJdkFullJvmArgs = if (useLibericaJdkFull) listOf(
     // javafx.base
     "--add-exports", "javafx.base/com.sun.javafx.event=org.jabref,ALL-UNNAMED",

--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
 }
 
 dependencies.constraints {
+    // With -PuseLibericaJdkFull=true, no org.openjfx:* dependency is requested (see
+    // org.jabref.gradle.base.dependency-rules.gradle.kts), so these JavaFX version pins stay inert.
     api("org.openjfx:javafx-base:$javafx")
     api("org.openjfx:javafx-controls:$javafx")
     api("org.openjfx:javafx-fxml:$javafx")


### PR DESCRIPTION
Trying to use [Liberica JDK Full](https://bell-sw.com/pages/downloads/) - which has JavaFX bundled.

<img width="554" height="572" alt="grafik" src="https://github.com/user-attachments/assets/1a210a3c-507d-4f5a-9a64-1cea93e678ef" />


---

```bash
mise install java@liberica-javafx-25.0.0
mise exec java@liberica-javafx-25.0.0 -- bash
./gradlew -PuseLibericaJdkFull :jabgui:run
```

NOTE: Gradle doesn't pick up that JDK https://github.com/gradle/gradle/issues/29355 - you really need to beg gradle!

`~/.gradle/gradle.properties`

```properties
# (ships JavaFX), which lives outside Gradle's built-in auto-detected locations.
# Needed for JabRef's -PuseLibericaJdkFull build (vendor = BellSoft).
org.gradle.java.installations.paths=/export/home/kopp/.local/share/mise/installs/java/liberica-javafx-25.0.0+37
```
