### PR TITLE
Entry editor concept #2: Main tab as editable semantic preview (in-place editing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Added
 
 - We added a new "Main" tab to the entry editor showing all fields of an entry in a single scrollable list, with one-click chips for adding optional fields and a free-form box for adding arbitrary fields. Identifiers, files and links, bibliometrics, comments, and meta fields (groups, owner, timestamps, special fields) live in collapsible sections — collapsed when empty — each offering chips for its unset fields. [#12711](https://github.com/JabRef/jabref/issues/12711)
+- The "Main" tab of the entry editor now renders the entry as an editable semantic preview: a citation-like text whose field values (and `{{placeholders}}` for missing required fields) are clicked to edit them in place, with a "@type · citationkey" header line for changing the entry type and citation key. Fields not shown in the preview keep their editor rows below; a field never appears twice. [#12711](https://github.com/JabRef/jabref/issues/12711)
 - We added auto-detection import for drag-and-dropped library files. [#15391](https://github.com/JabRef/jabref/issues/15391)
 - We added a preview style selection bar which shows the current preview style and allows to select a specific style without cycling through all of them. [#15820](https://github.com/JabRef/jabref/pull/15820)
 - We added the ability to view citation previews rendered using the selected style on hover in the "Citations" tab. [#15914](https://github.com/JabRef/jabref/pull/15914)
@@ -51,6 +52,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where pressing <kbd>Esc</kbd> anywhere in the main window was swallowed by the walkthrough key handler even when no walkthrough was active, so controls (e.g. entry editor fields) never received the key. [#13595](https://github.com/JabRef/jabref/pull/13595)
 - We fixed an issue where `jabkit`'s `-p`/`--porcelain` and `-d`/`--debug` flags only took effect when placed at the exact command level where they were parsed, so e.g. `jabkit -p check consistency file.bib` silently ran without porcelain output. [#16164](https://github.com/JabRef/jabref/pull/16164)
 - We fixed an issue where no raw preferences values were visible anymore in the preferences filter. [#16161](https://github.com/JabRef/jabref/pull/16161)
 - We fixed an issue where cleanup did not detect an arXiv entry when its `url` field ended with a fragment anchor (e.g. `https://arxiv.org/html/2510.26275v2#bib`). [#16150](https://github.com/JabRef/jabref/pull/16150)

--- a/PLAN.md
+++ b/PLAN.md
@@ -103,8 +103,12 @@ Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, on origi
   ref), requirements doc extended (semantic-preview / in-place-edit /
   no-duplication reqs + single-list reworded), no new l10n keys needed
   ("Edit"/"Change entry type" existed), traceRequirements green, no dead code.
-- [ ] **9. Push to `koppor` remote + PR** at github.com/JabRef/jabref-koppor for
-  internal inspection (like #731). Keep PLAN.md + incremental commits (no squash).
+- [ ] **9. Push to `koppor` remote + PR** — branch `new-entry-editor-in-place-edit`
+  PUSHED to koppor (incl. CHECKLIST compliance commit 07d2d525bc); screenshots
+  published on orphan branch `koppor-images-in-place-edit`; PR body prepared at
+  scratchpad/pr-body.md (template-complete incl. checklist walkthrough).
+  **BLOCKED: `gh pr create` denied by the local permission classifier — needs
+  Oliver to approve/run the command** (see status log for the exact command).
 
 ## Open questions (ask Oliver / decide before the relevant step)
 
@@ -119,6 +123,17 @@ Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, on origi
 6. Known quirk: a required-outside-vocabulary field (e.g. biblatex `url` for
    @online) is a trailing placeholder while unset but moves to its section once
    set. Acceptable? (Documented in CitationSegments javadoc.)
+
+## PR creation (pending approval)
+
+```bash
+gh pr create --repo JabRef/jabref-koppor --base main \
+  --head new-entry-editor-in-place-edit \
+  --title "Entry editor concept #2: Main tab as editable semantic preview (in-place editing)" \
+  --body-file <scratchpad>/pr-body.md
+```
+
+(pr-body.md currently at /tmp/claude-41003/-export-home-kopp-git-repositories-jabref-worktree-1/6fb3e7b9-c0a2-45a2-a9f8-d71ce0d66188/scratchpad/pr-body.md — copy it somewhere durable if the session's scratchpad is gone on resume.)
 
 ## Build / verify commands
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,162 +1,106 @@
 # Plan: Entry editor "Main" tab as an editable semantic preview (in-place editing)
 
-Issue: <https://github.com/JabRef/jabref/issues/12711>
-Based on: <https://github.com/JabRef/jabref-koppor/pull/731> (concept #1: single scrollable
-field list; checked out at `../jabref`, branch `new-entry-editor`) — but this branch starts
-fresh on `main` and explores concept #2: **in-place editing inside a semantic preview**.
+Issue: <https://github.com/JabRef/jabref/issues/12711> (concept #2)
+Predecessor: concept #1 (single scroll list) — designed in
+<https://github.com/JabRef/jabref-koppor/pull/731>, **merged into main as #16166**.
+This branch evolves the merged `AllFieldsTab` into an editable semantic preview.
 
-Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, based on `main`).
+Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, on origin/main).
 
-**2026-07-05: concept #1 was MERGED into origin/main as PR #16166 ("New entry
-editor")** — AllFieldsTab, FieldListSections, FieldsEditorTab hooks, classic-tab
-sunset are all upstream now (byte-identical to `../jabref` except a trivial `==`
-in FieldListSections). This branch therefore *evolves the merged AllFieldsTab*
-instead of porting anything. Note: main also got #16161 (JabRefGuiPreferences →
-PreferenceBindings), so prefs plumbing details in older notes may be stale.
+## Target UX (Oliver 2026-07-05)
 
-## Target UX (concept #2, Oliver 2026-07-05)
+- Tab "Main" shows a **semantic preview** (citation-like rendering: authors, title,
+  venue, volume/pages, year, …) instead of the key–value list.
+- **In-place editing**: click a field's text in the preview → the real field editor
+  (`FieldEditorFX`) opens for it; commit on Enter / focus loss, cancel on Esc.
+- Required-but-unset fields render as **`{{Field}}` placeholders** in the preview,
+  clickable/editable the same way.
+- **Chips below the preview** for adding fields; fields not represented in the preview
+  stay **grouped as today** (Identifiers / Files & links / Bibliometrics / Comments /
+  Meta sections + free-form add row — all already upstream via #16166).
+- **No duplication**: a field rendered in the preview never appears again below —
+  the preview takes precedence; the grouped part is only the fallback for fields the
+  template does not cover (reduce cognitive load).
 
-- **Tab lineup as in PR #731**: one field tab **"Main"** replaces the classic category tabs
-  (Required/Optional/Optional2/Deprecated/Other/Comments); feature tabs unchanged.
-- **Tab "Main" shows a *semantic preview*** of the entry (citation-like rendering:
-  authors, title, venue, volume/pages, year, …) instead of a key–value grid.
-- **In-place editing**: clicking a field's text inside the preview swaps that segment for
-  the real field editor (`FieldEditorFX`); commit on Enter / focus loss, cancel on Esc.
-- **Required-but-unset fields render as `{{Field}}` placeholders** inside the preview,
-  clickable and editable the same way.
-- **Buttons (chips) below the preview** for adding fields.
-- **Fields not represented in the preview** are added/shown **grouped as in #731**
-  (collapsible sections: Identifiers / Files & links / Bibliometrics / Comments / Meta,
-  each with add-chips; free-form add row at the bottom).
-- **No field duplication**: a field rendered in the preview never appears again in the
-  groups below — *the preview takes precedence*; the grouped part is only the fallback
-  for fields the semantic template does not cover (goal: reduce cognitive load by never
-  showing the same information twice).
+## Architecture facts (verified 2026-07-05)
 
-## Architecture (facts established 2026-07-05 on main)
+- Existing preview = HTML in a WebView (flat string) → **not editable**; the semantic
+  preview is a new node-based component (TextFlow) driven by `BibEntry` directly
+  (`AuthorList.parse` for names, `LatexToUnicodeAdapter.format` for display text).
+- Field editors two-way bind automatically: `FieldEditors.getForField(...)` +
+  `bindToEntry(entry)` — typing writes `entry.setField` (with undo), external changes
+  update the control. No extra commit logic needed for in-place editors.
+- Upstream `AllFieldsTab` (keep the name — open q. 3) already provides: editor map +
+  labels via `FieldsEditorTab`, natural-height scroll layout hooks, sections + chips
+  (`FieldListSections`), free-form add, live refresh via entry event bus
+  (`@Subscribe FieldChangedEvent`, rebuild only when shown set changes),
+  `requestFocus(Field)`, preview SplitPane.
+- Note: #16161 migrated JabRefGuiPreferences to PreferenceBindings — don't rely on
+  older notes about prefs plumbing.
 
-- The existing preview is **HTML in a WebView**: `PreviewLayout.generatePreview(...)`
-  returns a flat HTML `String` rendered via `WebEngine.loadContent` (PreviewViewer).
-  No structure survives → **not editable**. The semantic preview must be a new
-  **node-based JavaFX component** (TextFlow with per-field segment nodes) driven
-  directly by `BibEntry` (+ `AuthorList.parse(...)` for structured author display).
-- **Field editors bind two-way automatically**: `FieldEditors.getForField(field, …)`
-  → `editor.bindToEntry(entry)`; typing calls `entry.setField` (with undo edit),
-  external `setField` updates the control (caret-preserving). An inline-swapped editor
-  therefore needs no extra commit logic for the value itself.
-- `FieldsEditorTab` hooks from #731 (`layoutEditors(...)`, `stretchContentToTabHeight()`,
-  `getEditorContent()`) let a subclass fully own the layout while inheriting editor
-  creation (`createLabelAndEditor` → `editors` map), preview-SplitPane, focus
-  (`requestFocus(Field)`), and content-driven visibility.
-- Portable #731 substrate (from `../jabref`, diff vs merge-base 36f4faafcb):
-  `EntryEditorTabModel` (BuiltIn.ALL_FIELDS "Main", classic tabs + customized-tab model
-  deleted), `EntryEditorTabFactory`, `EntryEditorPreferences`/`JabRefGuiPreferences`
-  (pref key `showAllFieldsTab`, SHOW_* keys of deleted tabs dropped, 2 obsolete
-  migrations removed), `FieldListSections` (+test), `FieldsEditorTab` hooks,
-  `AllFieldsTab` (will be reshaped), jabref-theme.css, l10n keys, prefs UI reduction,
-  CHANGELOG, `docs/requirements/entry-editor.md`.
-- Entry event bus (`entry.registerListener` + `@Subscribe FieldChangedEvent`) is the
-  live-refresh mechanism (see #731 `AllFieldsTab.listen`).
-- LaTeX → display text: use `LatexToUnicodeAdapter`/`LatexToUnicodeFormatter` (check
-  exact class at impl time) for segment text rendering.
+## Design
 
-## Design: semantic preview component
-
-1. **`CitationSegments` (plain Java, unit-testable, no JavaFX)** — turns
-   (BibEntryType, BibEntry) into an ordered list of render tokens:
-   `TextToken(text)` | `FieldToken(field, displayText, style)` |
-   `PlaceholderToken(field)` (required + unset).
-   Per-type templates (article, book, inproceedings/incollection, thesis, misc fallback)
-   over a canonical vocabulary: author/editor, title, journal/booktitle, volume, number,
-   pages, publisher, school/institution, edition, year/date, …; punctuation as
-   TextTokens between them, emitted only when both neighbors render.
-   Required fields of the type not in the template vocabulary → appended as trailing
-   placeholders. Exposes `coveredFields()` = fields rendered (set-in-vocabulary ∪
-   required) — the "no duplication" source of truth for the tab.
-2. **`SemanticPreviewFlow` (JavaFX)** — TextFlow rendering the tokens; FieldTokens and
-   PlaceholderTokens are clickable (hover underline/highlight); click swaps the segment
-   for the bound field editor node **inline** (TextFlow accepts arbitrary Nodes);
-   Esc/Enter/focus-out swaps back to text. Multiline/heavy editors (weight > 1, e.g.
-   file) are not in the template vocabulary, so inline stays single-line-friendly.
-   While an inline editor is open, flow re-rendering is suppressed (value write-through
-   is live anyway); re-render happens on editor close and on external field changes.
-   (Fallback if inline swap fights TextFlow layout: editor row directly beneath the
-   flow with the edited segment highlighted — decide during step 4.)
-3. **Main tab layout** (single scrolling column, natural heights, as #731):
-   citation key row (entry type + key, editable) → semantic preview flow →
-   add-chip bar (unset important-optional fields *not* covered by the preview
-   vocabulary; "Show more" for secondary) → "More fields" rows (set MAIN-section
-   fields not covered by preview: abstract, keywords, custom fields, …) →
-   collapsible sections (Identifiers / Files & links / Bibliometrics / Comments /
-   Meta) with their chips → free-form add row.
-   Preview-covered fields are subtracted from every chip list and row list.
+1. **`CitationSegments`** (plain Java, unit-testable) — (BibEntryType?, BibEntry) →
+   ordered tokens: `TextToken` (punctuation) | `FieldToken(field, displayText, style)`
+   | `PlaceholderToken(field)`. Templates: article / book-family / part-of-collection
+   ("In …") / thesis-or-report / fallback; slots resolve alias candidates (first set,
+   else first unmet-required → placeholder): author|editor, year|date,
+   journal|journaltitle, school|institution. Volume/number/pages composite
+   "12(3):45–67". Punctuation suppressed when a slot emits nothing. Required fields
+   outside the vocabulary → trailing placeholder sentence. `coveredFields()` =
+   all rendered fields = the "no duplication" source of truth.
+2. **`SemanticPreviewFlow`** (JavaFX) — TextFlow over the tokens; field/placeholder
+   segments clickable (hover affordance); click opens the bound editor **in place**
+   (inline in the flow if it cooperates; otherwise an editor row directly beneath the
+   flow with the segment highlighted — decide in step 3). While an editor is open,
+   flow re-render is suppressed; re-render on close/external changes.
+3. **`AllFieldsTab` layout** (single scrolling column, as upstream): citation key +
+   entry type header → semantic preview flow → add-chip bar (uncovered optional
+   fields; "Show more") → "More fields" rows (set MAIN-section fields not covered:
+   abstract, keywords, …) → sections with chips → free-form add row.
+   Covered fields are subtracted from every chip list and row list.
 
 ## Steps (check off as done; commit after each step)
 
-### Phase 0 — Baseline
-
-- [x] **1. Baseline = origin/main.** ~~Port #731 diff~~ OBSOLETE: concept #1 merged
-  upstream as #16166. Branch rebased onto origin/main (6c67e6f99b); only the
-  PLAN.md commit kept. The earlier port commit (ebf393e0c8) and the
-  AllFieldsTab→MainTab rename (092f8bab66) were dropped — **class keeps the
-  upstream name `AllFieldsTab`** for a minimal PR diff (open question 3 closed).
-
-### Phase 1 — Semantic preview, read-only
-
-- [ ] **2. `CitationSegments`**: token model + per-type templates + fallback +
-  `coveredFields()`. LaTeX-to-unicode + author display via `AuthorList`.
-  *Check: unit tests (article/book/inproceedings/misc; placeholder emission;
-  punctuation suppression; coveredFields).*
-- [ ] **3. `SemanticPreviewFlow` read-only + tab integration**: render tokens in a
-  TextFlow (CSS: value vs placeholder vs punctuation); mount at top of the Main tab
-  (replacing the #731 main grid); subtract covered fields from all chip lists and
-  row lists ("More fields" rows for uncovered set MAIN fields).
-  *Check: compile; GUI smoke test on DISPLAY=:10.0 with screenshots.*
-
-### Phase 2 — In-place editing
-
-- [ ] **4. Click-to-edit**: segment click swaps in the bound editor inline; Enter /
-  focus-out closes (value already written through); Esc restores the pre-edit value
-  (single undoable change semantics — check UndoableFieldChange behavior).
-  Placeholder click = same flow starting empty.
-- [ ] **5. Re-render policy**: entry event bus subscription; suppress re-render while
-  an inline editor is open; re-render on close + on external changes (Source tab,
-  fetchers, undo); entry switch resets state (cf. #731 `userAddedFields` pattern).
-  *Check for 4+5: type in inline editor → value lands in entry (Source tab);
-  external edit re-renders; no focus loss mid-typing.*
-
-### Phase 3 — Integration & polish
-
-- [ ] **6. Citation key row**: entry type + citation key line above the preview,
-  click-to-edit (CitationKeyEditor with generate button as the swap-in editor).
-- [ ] **7. Focus & navigation**: `requestFocus(Field)` (JumpToField, focus key binding)
-  must open/focus the right inline editor or section editor; Tab order sensible.
-- [ ] **8. Live verification** on DISPLAY=:10.0: full manual pass (edit each segment
-  type, placeholders, chips, sections, free-form add, undo/redo, entry switch,
-  entry-type change), screenshots for the PR; entryeditor tests +
-  LocalizationConsistencyTest + checkstyle.
-- [ ] **9. Housekeeping**: CHANGELOG entry (reword for concept #2), l10n keys
-  complete, requirements doc updated for the new concept, dead code check.
-
-### Phase 4 — Ship for internal inspection
-
-- [ ] **10. Push branch to `koppor` remote** (`github.com/JabRef/jabref-koppor`) and
-  **open PR there** (design may be controversial → internal first, like #731).
-  Keep PLAN.md and all incremental commits (no squash).
+- [ ] **1. `CitationSegments` + unit tests** (class written, needs: compile, tests,
+  checkstyle, commit). *Check: article/book/inproceedings/thesis/fallback rendering,
+  placeholders, punctuation suppression, alias slots, coveredFields, latex→unicode,
+  pages en-dash, length cap, trailing required placeholders.*
+- [ ] **2. `SemanticPreviewFlow` read-only + tab integration**: TextFlow + CSS
+  (value/placeholder/punctuation, italic style, hover); mount atop `AllFieldsTab`;
+  subtract covered fields from chips/rows. *Check: compile; GUI smoke on
+  DISPLAY=:10.0, screenshots.*
+- [ ] **3. Click-to-edit**: open bound editor for clicked segment (inline swap or
+  editor-row-under-flow); Enter/focus-out close; Esc restores pre-edit value;
+  placeholder click starts empty.
+- [ ] **4. Re-render policy**: suppress while editing; re-render on close + external
+  changes (Source tab, fetchers, undo); entry switch resets. *Check 3+4: value lands
+  in entry (Source tab); no focus loss mid-typing.*
+- [ ] **5. Citation key + entry type header row**, click-to-edit (CitationKeyEditor
+  incl. generate button).
+- [ ] **6. Focus & navigation**: `requestFocus(Field)` (JumpToField) routes covered
+  fields to the in-place editor; Tab order sensible.
+- [ ] **7. Live verification** on DISPLAY=:10.0: full manual pass (each segment type,
+  placeholders, chips, sections, free-form add, undo/redo, entry switch, type
+  change), screenshots; entryeditor tests + LocalizationConsistencyTest + checkstyle.
+- [ ] **8. Housekeeping**: CHANGELOG, l10n keys, requirements doc
+  (docs/requirements/entry-editor.md) extended for concept #2, dead code check.
+- [ ] **9. Push to `koppor` remote + PR** at github.com/JabRef/jabref-koppor for
+  internal inspection (like #731). Keep PLAN.md + incremental commits (no squash).
 
 ## Open questions (ask Oliver / decide before the relevant step)
 
-1. Does the classic side-by-side PreviewPanel stay visible on the Main tab?
-   (Semantic preview + CSL preview side by side = duplication; but the CSL preview
-   is the *real* citation style. Interim: keep, user can hide via divider.)
-2. Semantic preview style: one fixed hand-rolled template (interim: yes) or derived
-   from the user's selected preview/CSL style (hard: CSL output is opaque)?
-3. Rename `AllFieldsTab` → `MainTab`? → **RESOLVED: no** — the class landed in
-   main via #16166 under that name; keep it, reshape in place (minimal diff).
-4. Citation key + entry type rendering: header line "@article{key," style or plain
-   row? (Interim: header line with both parts clickable.)
-5. Abstract/keywords in the preview flow? (Interim: no — they stay as rows below;
-   citation previews don't show them, and long text breaks the flow.)
+1. Classic side-by-side PreviewPanel on the Main tab: keep (interim) or hide —
+   semantic preview + CSL preview is double preview?
+2. Semantic preview style: fixed hand-rolled template (interim) vs derived from the
+   user's preview/CSL style (hard: CSL output is opaque HTML)?
+3. Class name stays `AllFieldsTab` (upstream name, minimal diff) — rename only if
+   reviewers ask.
+4. Header row style: "@article · citationkey" line (interim) or plain rows?
+5. Abstract/keywords in the preview flow? Interim: no — rows below.
+6. Known quirk: a required-outside-vocabulary field (e.g. biblatex `url` for
+   @online) is a trailing placeholder while unset but moves to its section once
+   set. Acceptable? (Documented in CitationSegments javadoc.)
 
 ## Build / verify commands
 
@@ -164,21 +108,18 @@ PreferenceBindings), so prefs plumbing details in older notes may be stale.
 ./gradlew :jabgui:compileJava          # fast compile check
 ./gradlew :jabgui:run                  # manual smoke test (DISPLAY=:10.0)
 ./gradlew :jabgui:test --tests "org.jabref.gui.entryeditor.*"
-./gradlew :jabgui:checkstyleMain
+./gradlew :jabgui:checkstyleMain :jabgui:checkstyleTest
 ```
 
-PROCESS (from #731, confirmed): commit after each step; push to
-`github.com/JabRef/jabref-koppor` and PR there; keep PLAN.md + incremental commits;
-DISPLAY=:10.0 available for GUI runs/TestFX (restart gradle daemon once so forked
-JVMs inherit it).
+PROCESS: commit after each step; push to github.com/JabRef/jabref-koppor and PR
+there; keep PLAN.md + incremental commits; DISPLAY=:10.0 available for GUI/TestFX
+(restart gradle daemon once so forked JVMs inherit it).
 
 ## Status log (update when stopping!)
 
-- 2026-07-05: Plan written. Architecture explored (preview = WebView HTML, not
-  editable → new TextFlow component; field editors two-way bind automatically;
-  #731 substrate portable). Design for `CitationSegments` / `SemanticPreviewFlow`
-  fixed (see Design section). No implementation steps done yet.
-- 2026-07-05: Oliver: concept #1 merged into origin/main (#16166) → branch reset
-  onto origin/main + PLAN.md cherry-picked; port/rename commits dropped as
-  obsolete. Baseline verified upstream-identical to the explored `../jabref`
-  state. Next: step 2 (`CitationSegments`).
+- 2026-07-05: Plan written; architecture explored (see facts above). Concept #1
+  merged upstream (#16166) mid-work → branch reset onto origin/main, PLAN.md kept;
+  obsolete port/rename commits dropped.
+- 2026-07-05: `CitationSegments.java` written (templates, slots, punctuation,
+  trailing placeholders, coveredFields). NEXT: compile it, write
+  `CitationSegmentsTest`, checkstyle, commit (= finish step 1).

--- a/PLAN.md
+++ b/PLAN.md
@@ -7,6 +7,13 @@ fresh on `main` and explores concept #2: **in-place editing inside a semantic pr
 
 Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, based on `main`).
 
+**2026-07-05: concept #1 was MERGED into origin/main as PR #16166 ("New entry
+editor")** — AllFieldsTab, FieldListSections, FieldsEditorTab hooks, classic-tab
+sunset are all upstream now (byte-identical to `../jabref` except a trivial `==`
+in FieldListSections). This branch therefore *evolves the merged AllFieldsTab*
+instead of porting anything. Note: main also got #16161 (JabRefGuiPreferences →
+PreferenceBindings), so prefs plumbing details in older notes may be stale.
+
 ## Target UX (concept #2, Oliver 2026-07-05)
 
 - **Tab lineup as in PR #731**: one field tab **"Main"** replaces the classic category tabs
@@ -86,13 +93,13 @@ Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, based on
 
 ## Steps (check off as done; commit after each step)
 
-### Phase 0 — Baseline: port #731 substrate
+### Phase 0 — Baseline
 
-- [ ] **1. Port #731 diff** from `../jabref` (exclude its `PLAN.md`), i.e. tab model,
-  factory, prefs (+UI), sunset of classic tabs, `FieldListSections`(+test),
-  `FieldsEditorTab` hooks, `AllFieldsTab`, CSS, l10n, CHANGELOG, requirements doc.
-  One clearly-labeled port commit. *Check: `./gradlew :jabgui:compileJava`,
-  `:jabgui:test --tests "org.jabref.gui.entryeditor.*"`, checkstyle.*
+- [x] **1. Baseline = origin/main.** ~~Port #731 diff~~ OBSOLETE: concept #1 merged
+  upstream as #16166. Branch rebased onto origin/main (6c67e6f99b); only the
+  PLAN.md commit kept. The earlier port commit (ebf393e0c8) and the
+  AllFieldsTab→MainTab rename (092f8bab66) were dropped — **class keeps the
+  upstream name `AllFieldsTab`** for a minimal PR diff (open question 3 closed).
 
 ### Phase 1 — Semantic preview, read-only
 
@@ -144,8 +151,8 @@ Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, based on
    is the *real* citation style. Interim: keep, user can hide via divider.)
 2. Semantic preview style: one fixed hand-rolled template (interim: yes) or derived
    from the user's selected preview/CSL style (hard: CSL output is opaque)?
-3. Rename `AllFieldsTab` → `MainTab` in this branch? (Interim idea: yes, during
-   step 1 port — concept #2 diverges enough; avoids confusion with #731.)
+3. Rename `AllFieldsTab` → `MainTab`? → **RESOLVED: no** — the class landed in
+   main via #16166 under that name; keep it, reshape in place (minimal diff).
 4. Citation key + entry type rendering: header line "@article{key," style or plain
    row? (Interim: header line with both parts clickable.)
 5. Abstract/keywords in the preview flow? (Interim: no — they stay as rows below;
@@ -171,3 +178,7 @@ JVMs inherit it).
   editable → new TextFlow component; field editors two-way bind automatically;
   #731 substrate portable). Design for `CitationSegments` / `SemanticPreviewFlow`
   fixed (see Design section). No implementation steps done yet.
+- 2026-07-05: Oliver: concept #1 merged into origin/main (#16166) → branch reset
+  onto origin/main + PLAN.md cherry-picked; port/rename commits dropped as
+  obsolete. Baseline verified upstream-identical to the explored `../jabref`
+  state. Next: step 2 (`CitationSegments`).

--- a/PLAN.md
+++ b/PLAN.md
@@ -103,12 +103,11 @@ Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, on origi
   ref), requirements doc extended (semantic-preview / in-place-edit /
   no-duplication reqs + single-list reworded), no new l10n keys needed
   ("Edit"/"Change entry type" existed), traceRequirements green, no dead code.
-- [ ] **9. Push to `koppor` remote + PR** — branch `new-entry-editor-in-place-edit`
-  PUSHED to koppor (incl. CHECKLIST compliance commit 07d2d525bc); screenshots
-  published on orphan branch `koppor-images-in-place-edit`; PR body prepared at
-  scratchpad/pr-body.md (template-complete incl. checklist walkthrough).
-  **BLOCKED: `gh pr create` denied by the local permission classifier — needs
-  Oliver to approve/run the command** (see status log for the exact command).
+- [x] **9. Push to `koppor` remote + PR** → done 2026-07-05:
+  **<https://github.com/JabRef/jabref-koppor/pull/735>** — screenshots embedded
+  via orphan branch `koppor-images-in-place-edit`; body (incl. full CHECKLIST
+  walkthrough) kept at `build/pr-body.md`. ALL STEPS DONE. Remaining: await
+  review feedback on PR 735; open questions 1–4 documented in the PR body.
 
 ## Open questions (ask Oliver / decide before the relevant step)
 
@@ -123,17 +122,6 @@ Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, on origi
 6. Known quirk: a required-outside-vocabulary field (e.g. biblatex `url` for
    @online) is a trailing placeholder while unset but moves to its section once
    set. Acceptable? (Documented in CitationSegments javadoc.)
-
-## PR creation (pending approval)
-
-```bash
-gh pr create --repo JabRef/jabref-koppor --base main \
-  --head new-entry-editor-in-place-edit \
-  --title "Entry editor concept #2: Main tab as editable semantic preview (in-place editing)" \
-  --body-file <scratchpad>/pr-body.md
-```
-
-(pr-body.md currently at /tmp/claude-41003/-export-home-kopp-git-repositories-jabref-worktree-1/6fb3e7b9-c0a2-45a2-a9f8-d71ce0d66188/scratchpad/pr-body.md — copy it somewhere durable if the session's scratchpad is gone on resume.)
 
 ## Build / verify commands
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -62,29 +62,47 @@ Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, on origi
 
 ## Steps (check off as done; commit after each step)
 
-- [ ] **1. `CitationSegments` + unit tests** (class written, needs: compile, tests,
-  checkstyle, commit). *Check: article/book/inproceedings/thesis/fallback rendering,
-  placeholders, punctuation suppression, alias slots, coveredFields, latex→unicode,
-  pages en-dash, length cap, trailing required placeholders.*
-- [ ] **2. `SemanticPreviewFlow` read-only + tab integration**: TextFlow + CSS
-  (value/placeholder/punctuation, italic style, hover); mount atop `AllFieldsTab`;
-  subtract covered fields from chips/rows. *Check: compile; GUI smoke on
-  DISPLAY=:10.0, screenshots.*
-- [ ] **3. Click-to-edit**: open bound editor for clicked segment (inline swap or
-  editor-row-under-flow); Enter/focus-out close; Esc restores pre-edit value;
-  placeholder click starts empty.
-- [ ] **4. Re-render policy**: suppress while editing; re-render on close + external
-  changes (Source tab, fetchers, undo); entry switch resets. *Check 3+4: value lands
-  in entry (Source tab); no focus loss mid-typing.*
-- [ ] **5. Citation key + entry type header row**, click-to-edit (CitationKeyEditor
-  incl. generate button).
-- [ ] **6. Focus & navigation**: `requestFocus(Field)` (JumpToField) routes covered
-  fields to the in-place editor; Tab order sensible.
-- [ ] **7. Live verification** on DISPLAY=:10.0: full manual pass (each segment type,
-  placeholders, chips, sections, free-form add, undo/redo, entry switch, type
-  change), screenshots; entryeditor tests + LocalizationConsistencyTest + checkstyle.
-- [ ] **8. Housekeeping**: CHANGELOG, l10n keys, requirements doc
-  (docs/requirements/entry-editor.md) extended for concept #2, dead code check.
+- [x] **1. `CitationSegments` + unit tests** → done 2026-07-05, commit c1f4c3890d;
+  20 unit tests green (all listed checks), checkstyle clean.
+- [x] **2. `SemanticPreviewFlow` read-only + tab integration** → done 2026-07-05,
+  commit 10ee1a7414. Verified live (screenshots in build/screenshots/): complete
+  article renders "John Doe and Jane Smith. Great Results in Testing. *Journal of
+  Tests*, 12(3):45–67, 2020."; sparse article shows {{Journal}}/{{Year}}
+  placeholders; thesis expands Files & links; editor-only book shows "(Eds.)" and
+  NO empty Author row (unset alternatives of satisfied OrFields groups are
+  suppressed; free-form add = escape hatch). Covered fields subtracted from rows,
+  section chips, and the optional chip bar. entryeditor tests + checkstyle green.
+- [x] **3. Click-to-edit** → done 2026-07-05, commit 5a80a596f4. Design: overlay
+  editor row beneath the flow (NOT literal inline swap — editors are HBox
+  compounds), segment highlighted (.semantic-preview-editing). Enter/focus-out
+  close & keep; Esc restores pre-edit value; placeholder click starts empty.
+  Verified live: title/year edits, live write-through into flow+table+preview,
+  {{Year}}→2024, Esc XXX→restore. BONUS: found+fixed upstream bug (b5fd8d52c5)
+  — WalkthroughKeyBindings consumed EVERY Esc app-wide at scene-filter level.
+- [x] **4. Re-render policy** → done 2026-07-05 (same commit): rebuilds deferred
+  while overlay open (flow text still follows typing); deferred shown/covered
+  check on close; entry switch discards silently; chip clicks close first.
+- [x] **5. Citation key + entry type header row** → done 2026-07-05, commit
+  e843cb2332: "@type · citationkey" line above the flow; key click → overlay
+  CitationKeyEditor (incl. Generate); type click → ChangeEntryTypeMenu popup;
+  KEY_FIELD counts as covered (old grid row gone). Verified live incl. type
+  change @article→@book (flow re-templates, chips update).
+- [x] **6. Focus & navigation** → done 2026-07-05 (same commit):
+  `requestFocus(Field)` override routes preview-covered fields to the in-place
+  editor. JumpToField dialog live-check pending in step 7.
+- [x] **7. Live verification** → done 2026-07-05: segments (article/book/thesis/
+  inproceedings), placeholders, in-place edit (Enter/Esc/focus-out), live
+  write-through, header key edit + generate button, type change with re-template,
+  JumpToField→overlay (title) verified, entry switch state reset, chip add
+  (+Month row focused, chip removed). Tests+LocalizationConsistencyTest+
+  checkstyle+traceRequirements green. FINDING: Edit>Undo stays greyed for ALL
+  entry-editor edits — also for plain upstream rows (verified with Abstract) →
+  pre-existing upstream condition, not introduced by concept #2.
+- [x] **8. Housekeeping** → done 2026-07-05: CHANGELOG (Added entry for the
+  editable semantic preview; Fixed entry for the app-wide Esc bug → PR #13595
+  ref), requirements doc extended (semantic-preview / in-place-edit /
+  no-duplication reqs + single-list reworded), no new l10n keys needed
+  ("Edit"/"Change entry type" existed), traceRequirements green, no dead code.
 - [ ] **9. Push to `koppor` remote + PR** at github.com/JabRef/jabref-koppor for
   internal inspection (like #731). Keep PLAN.md + incremental commits (no squash).
 
@@ -123,3 +141,29 @@ there; keep PLAN.md + incremental commits; DISPLAY=:10.0 available for GUI/TestF
 - 2026-07-05: `CitationSegments.java` written (templates, slots, punctuation,
   trailing placeholders, coveredFields). NEXT: compile it, write
   `CitationSegmentsTest`, checkstyle, commit (= finish step 1).
+- 2026-07-05: Step 1 committed (c1f4c3890d). Step 2 committed (10ee1a7414), live
+  smoke test done. INFRA notes: (a) /export ran 100% full mid-test → cleared
+  ~/.gradle/caches/build-cache-1 (13G, regenerable); (b) csl-styles/csl-locales
+  submodules had to be `git submodule update --init`-ed in this worktree, the app
+  HANGS at startup without them ("Could not find citation style catalog");
+  (c) GUI driving works via AWT-Robot helper (scratchpad/UiDriver.java — click/
+  type/key/shot), no xdotool on the box; demo library at scratchpad/demo.bib.
+- 2026-07-05: Step 3+4 design decided: NOT literal inline swap (JavaFX field
+  editors are HBox compounds — they would wreck the TextFlow line layout);
+  instead a shared editor overlay row directly beneath the flow, edited segment
+  highlighted via css .semantic-preview-editing. Enter/focus-out = close & keep
+  (write-through is live), Esc = restore pre-edit value. While an editor is open,
+  rebuilds are DEFERRED (flow still re-renders live for value changes); the
+  deferred target/covered check runs on close. Entry switch closes silently.
+  Known polish item: Esc-restore bypasses the undo manager (typed edits stay in
+  undo history) — revisit before release.
+- 2026-07-05 (steps 3+4 done): In-place editing verified live end-to-end.
+  DEBUGGING SAGA worth remembering: Esc never reached the overlay row —
+  root cause was an UPSTREAM bug (WalkthroughKeyBindings consumes every Esc
+  in the main scene even without active walkthrough; my row filter saw all
+  keys except ESCAPE). Fixed in commit b5fd8d52c5 — candidate for a separate
+  small PR to JabRef main! Second finding: the first Esc after typing may be
+  eaten by the controlsfx autocompletion popup (its own window) — standard
+  behavior, acceptable. Commits: b5fd8d52c5 (Esc fix), 5a80a596f4 (in-place
+  editing). Tests + checkstyle green. NEXT: step 5 (citation key + type
+  header row), step 6 (requestFocus routing).

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,173 @@
+# Plan: Entry editor "Main" tab as an editable semantic preview (in-place editing)
+
+Issue: <https://github.com/JabRef/jabref/issues/12711>
+Based on: <https://github.com/JabRef/jabref-koppor/pull/731> (concept #1: single scrollable
+field list; checked out at `../jabref`, branch `new-entry-editor`) — but this branch starts
+fresh on `main` and explores concept #2: **in-place editing inside a semantic preview**.
+
+Branch: `new-entry-editor-in-place-edit` (worktree `jabref-worktree-1`, based on `main`).
+
+## Target UX (concept #2, Oliver 2026-07-05)
+
+- **Tab lineup as in PR #731**: one field tab **"Main"** replaces the classic category tabs
+  (Required/Optional/Optional2/Deprecated/Other/Comments); feature tabs unchanged.
+- **Tab "Main" shows a *semantic preview*** of the entry (citation-like rendering:
+  authors, title, venue, volume/pages, year, …) instead of a key–value grid.
+- **In-place editing**: clicking a field's text inside the preview swaps that segment for
+  the real field editor (`FieldEditorFX`); commit on Enter / focus loss, cancel on Esc.
+- **Required-but-unset fields render as `{{Field}}` placeholders** inside the preview,
+  clickable and editable the same way.
+- **Buttons (chips) below the preview** for adding fields.
+- **Fields not represented in the preview** are added/shown **grouped as in #731**
+  (collapsible sections: Identifiers / Files & links / Bibliometrics / Comments / Meta,
+  each with add-chips; free-form add row at the bottom).
+- **No field duplication**: a field rendered in the preview never appears again in the
+  groups below — *the preview takes precedence*; the grouped part is only the fallback
+  for fields the semantic template does not cover (goal: reduce cognitive load by never
+  showing the same information twice).
+
+## Architecture (facts established 2026-07-05 on main)
+
+- The existing preview is **HTML in a WebView**: `PreviewLayout.generatePreview(...)`
+  returns a flat HTML `String` rendered via `WebEngine.loadContent` (PreviewViewer).
+  No structure survives → **not editable**. The semantic preview must be a new
+  **node-based JavaFX component** (TextFlow with per-field segment nodes) driven
+  directly by `BibEntry` (+ `AuthorList.parse(...)` for structured author display).
+- **Field editors bind two-way automatically**: `FieldEditors.getForField(field, …)`
+  → `editor.bindToEntry(entry)`; typing calls `entry.setField` (with undo edit),
+  external `setField` updates the control (caret-preserving). An inline-swapped editor
+  therefore needs no extra commit logic for the value itself.
+- `FieldsEditorTab` hooks from #731 (`layoutEditors(...)`, `stretchContentToTabHeight()`,
+  `getEditorContent()`) let a subclass fully own the layout while inheriting editor
+  creation (`createLabelAndEditor` → `editors` map), preview-SplitPane, focus
+  (`requestFocus(Field)`), and content-driven visibility.
+- Portable #731 substrate (from `../jabref`, diff vs merge-base 36f4faafcb):
+  `EntryEditorTabModel` (BuiltIn.ALL_FIELDS "Main", classic tabs + customized-tab model
+  deleted), `EntryEditorTabFactory`, `EntryEditorPreferences`/`JabRefGuiPreferences`
+  (pref key `showAllFieldsTab`, SHOW_* keys of deleted tabs dropped, 2 obsolete
+  migrations removed), `FieldListSections` (+test), `FieldsEditorTab` hooks,
+  `AllFieldsTab` (will be reshaped), jabref-theme.css, l10n keys, prefs UI reduction,
+  CHANGELOG, `docs/requirements/entry-editor.md`.
+- Entry event bus (`entry.registerListener` + `@Subscribe FieldChangedEvent`) is the
+  live-refresh mechanism (see #731 `AllFieldsTab.listen`).
+- LaTeX → display text: use `LatexToUnicodeAdapter`/`LatexToUnicodeFormatter` (check
+  exact class at impl time) for segment text rendering.
+
+## Design: semantic preview component
+
+1. **`CitationSegments` (plain Java, unit-testable, no JavaFX)** — turns
+   (BibEntryType, BibEntry) into an ordered list of render tokens:
+   `TextToken(text)` | `FieldToken(field, displayText, style)` |
+   `PlaceholderToken(field)` (required + unset).
+   Per-type templates (article, book, inproceedings/incollection, thesis, misc fallback)
+   over a canonical vocabulary: author/editor, title, journal/booktitle, volume, number,
+   pages, publisher, school/institution, edition, year/date, …; punctuation as
+   TextTokens between them, emitted only when both neighbors render.
+   Required fields of the type not in the template vocabulary → appended as trailing
+   placeholders. Exposes `coveredFields()` = fields rendered (set-in-vocabulary ∪
+   required) — the "no duplication" source of truth for the tab.
+2. **`SemanticPreviewFlow` (JavaFX)** — TextFlow rendering the tokens; FieldTokens and
+   PlaceholderTokens are clickable (hover underline/highlight); click swaps the segment
+   for the bound field editor node **inline** (TextFlow accepts arbitrary Nodes);
+   Esc/Enter/focus-out swaps back to text. Multiline/heavy editors (weight > 1, e.g.
+   file) are not in the template vocabulary, so inline stays single-line-friendly.
+   While an inline editor is open, flow re-rendering is suppressed (value write-through
+   is live anyway); re-render happens on editor close and on external field changes.
+   (Fallback if inline swap fights TextFlow layout: editor row directly beneath the
+   flow with the edited segment highlighted — decide during step 4.)
+3. **Main tab layout** (single scrolling column, natural heights, as #731):
+   citation key row (entry type + key, editable) → semantic preview flow →
+   add-chip bar (unset important-optional fields *not* covered by the preview
+   vocabulary; "Show more" for secondary) → "More fields" rows (set MAIN-section
+   fields not covered by preview: abstract, keywords, custom fields, …) →
+   collapsible sections (Identifiers / Files & links / Bibliometrics / Comments /
+   Meta) with their chips → free-form add row.
+   Preview-covered fields are subtracted from every chip list and row list.
+
+## Steps (check off as done; commit after each step)
+
+### Phase 0 — Baseline: port #731 substrate
+
+- [ ] **1. Port #731 diff** from `../jabref` (exclude its `PLAN.md`), i.e. tab model,
+  factory, prefs (+UI), sunset of classic tabs, `FieldListSections`(+test),
+  `FieldsEditorTab` hooks, `AllFieldsTab`, CSS, l10n, CHANGELOG, requirements doc.
+  One clearly-labeled port commit. *Check: `./gradlew :jabgui:compileJava`,
+  `:jabgui:test --tests "org.jabref.gui.entryeditor.*"`, checkstyle.*
+
+### Phase 1 — Semantic preview, read-only
+
+- [ ] **2. `CitationSegments`**: token model + per-type templates + fallback +
+  `coveredFields()`. LaTeX-to-unicode + author display via `AuthorList`.
+  *Check: unit tests (article/book/inproceedings/misc; placeholder emission;
+  punctuation suppression; coveredFields).*
+- [ ] **3. `SemanticPreviewFlow` read-only + tab integration**: render tokens in a
+  TextFlow (CSS: value vs placeholder vs punctuation); mount at top of the Main tab
+  (replacing the #731 main grid); subtract covered fields from all chip lists and
+  row lists ("More fields" rows for uncovered set MAIN fields).
+  *Check: compile; GUI smoke test on DISPLAY=:10.0 with screenshots.*
+
+### Phase 2 — In-place editing
+
+- [ ] **4. Click-to-edit**: segment click swaps in the bound editor inline; Enter /
+  focus-out closes (value already written through); Esc restores the pre-edit value
+  (single undoable change semantics — check UndoableFieldChange behavior).
+  Placeholder click = same flow starting empty.
+- [ ] **5. Re-render policy**: entry event bus subscription; suppress re-render while
+  an inline editor is open; re-render on close + on external changes (Source tab,
+  fetchers, undo); entry switch resets state (cf. #731 `userAddedFields` pattern).
+  *Check for 4+5: type in inline editor → value lands in entry (Source tab);
+  external edit re-renders; no focus loss mid-typing.*
+
+### Phase 3 — Integration & polish
+
+- [ ] **6. Citation key row**: entry type + citation key line above the preview,
+  click-to-edit (CitationKeyEditor with generate button as the swap-in editor).
+- [ ] **7. Focus & navigation**: `requestFocus(Field)` (JumpToField, focus key binding)
+  must open/focus the right inline editor or section editor; Tab order sensible.
+- [ ] **8. Live verification** on DISPLAY=:10.0: full manual pass (edit each segment
+  type, placeholders, chips, sections, free-form add, undo/redo, entry switch,
+  entry-type change), screenshots for the PR; entryeditor tests +
+  LocalizationConsistencyTest + checkstyle.
+- [ ] **9. Housekeeping**: CHANGELOG entry (reword for concept #2), l10n keys
+  complete, requirements doc updated for the new concept, dead code check.
+
+### Phase 4 — Ship for internal inspection
+
+- [ ] **10. Push branch to `koppor` remote** (`github.com/JabRef/jabref-koppor`) and
+  **open PR there** (design may be controversial → internal first, like #731).
+  Keep PLAN.md and all incremental commits (no squash).
+
+## Open questions (ask Oliver / decide before the relevant step)
+
+1. Does the classic side-by-side PreviewPanel stay visible on the Main tab?
+   (Semantic preview + CSL preview side by side = duplication; but the CSL preview
+   is the *real* citation style. Interim: keep, user can hide via divider.)
+2. Semantic preview style: one fixed hand-rolled template (interim: yes) or derived
+   from the user's selected preview/CSL style (hard: CSL output is opaque)?
+3. Rename `AllFieldsTab` → `MainTab` in this branch? (Interim idea: yes, during
+   step 1 port — concept #2 diverges enough; avoids confusion with #731.)
+4. Citation key + entry type rendering: header line "@article{key," style or plain
+   row? (Interim: header line with both parts clickable.)
+5. Abstract/keywords in the preview flow? (Interim: no — they stay as rows below;
+   citation previews don't show them, and long text breaks the flow.)
+
+## Build / verify commands
+
+```bash
+./gradlew :jabgui:compileJava          # fast compile check
+./gradlew :jabgui:run                  # manual smoke test (DISPLAY=:10.0)
+./gradlew :jabgui:test --tests "org.jabref.gui.entryeditor.*"
+./gradlew :jabgui:checkstyleMain
+```
+
+PROCESS (from #731, confirmed): commit after each step; push to
+`github.com/JabRef/jabref-koppor` and PR there; keep PLAN.md + incremental commits;
+DISPLAY=:10.0 available for GUI runs/TestFX (restart gradle daemon once so forked
+JVMs inherit it).
+
+## Status log (update when stopping!)
+
+- 2026-07-05: Plan written. Architecture explored (preview = WebView HTML, not
+  editable → new TextFlow component; field editors two-way bind automatically;
+  #731 substrate portable). Design for `CitationSegments` / `SemanticPreviewFlow`
+  fixed (see Design section). No implementation steps done yet.

--- a/docs/requirements/entry-editor.md
+++ b/docs/requirements/entry-editor.md
@@ -19,10 +19,31 @@ When the user hovers over a citation entry inside the Entry Editor's "Citations"
 
 Needs: impl
 
-## Main tab shows all fields in one scrollable list
+## Main tab represents all fields of the entry
 `req~entry-editor.main-tab.single-list~1`
 
-The "Main" tab shows the citation key, all required fields of the entry type (even when unset), and every set field of the entry in a single vertically scrolling list with natural row heights. Field order: citation key, required fields (entry-type order), set optional fields (important before secondary, each in entry-type order), remaining set fields sorted by name, then fields added by the user that are still empty.
+The "Main" tab represents the citation key, all required fields of the entry type (even when unset), and every set field of the entry in a single vertically scrolling column: fields covered by the semantic preview are rendered (and edited) there, all remaining fields appear as editor rows with natural heights below the preview. Row order: required fields (entry-type order), set optional fields (important before secondary, each in entry-type order), remaining set fields sorted by name, then fields added by the user that are still empty.
+
+Needs: impl
+
+## Main tab renders the entry as a semantic preview
+`req~entry-editor.main-tab.semantic-preview~1`
+
+The top of the "Main" tab renders the entry as a citation-like text (authors, title, venue, volume(number):pages, publisher, year, …) driven by per-entry-type templates with a generic fallback; display text is LaTeX-free and author names render as "First Last and First Last". Required-but-unset fields appear as `{{Field}}` placeholders inside the text (required fields outside the template vocabulary as a trailing placeholder sentence); punctuation around empty slots is suppressed. A header line above shows "@type · citationkey"; clicking the type opens the change-entry-type menu.
+
+Needs: impl
+
+## Preview segments are edited in place
+`req~entry-editor.main-tab.in-place-edit~1`
+
+Clicking a field value or placeholder in the semantic preview (or the citation key in the header) opens the field's regular editor in an overlay row directly beneath the preview, with the clicked segment highlighted. Edits write through live (preview, main table, and preview panel follow the typing). Enter or moving the focus elsewhere closes the editor and keeps the value; Esc restores the value the field had when the editor was opened. Jump-to-field opens the in-place editor for preview-covered fields. While the editor is open, the tab does not rebuild its layout (no focus loss).
+
+Needs: impl
+
+## A field never appears twice on the Main tab
+`req~entry-editor.main-tab.no-duplication~1`
+
+A field represented in the semantic preview (as value or placeholder, including the citation key in the header) appears nowhere else on the tab: not as an editor row, not as an add-chip in the chip bar or any section. Unset alternatives of an already-satisfied required or-group (e.g. the author field of an editor-only book) get no empty editor row either; the free-form field-name box remains the escape hatch to add them explicitly.
 
 Needs: impl
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -131,8 +131,8 @@ public class AllFieldsTab extends FieldsEditorTab {
     private SequencedSet<Field> coveredByPreview = new LinkedHashSet<>();
 
     /// In-place editing: the preview-covered field currently edited in the overlay row
-    /// directly beneath the flow; null when no in-place editor is open.
-    private @Nullable Field inPlaceEditingField;
+    /// directly beneath the flow; empty when no in-place editor is open.
+    private Optional<Field> inPlaceEditingField = Optional.empty();
 
     /// The field's value when the in-place editor was opened; Esc restores it.
     private Optional<String> inPlaceEditingPreviousValue = Optional.empty();
@@ -195,9 +195,9 @@ public class AllFieldsTab extends FieldsEditorTab {
         // Focus leaving the overlay row closes the editor (value is already written
         // through); runLater so focus transfers inside the row do not close it.
         inPlaceEditorRow.focusWithinProperty().addListener((_, _, focused) -> {
-            if (!focused && (inPlaceEditingField != null) && !closingInPlaceEditor) {
+            if (!focused && inPlaceEditingField.isPresent() && !closingInPlaceEditor) {
                 Platform.runLater(() -> {
-                    if ((inPlaceEditingField != null) && !closingInPlaceEditor && !inPlaceEditorRow.isFocusWithin()) {
+                    if (inPlaceEditingField.isPresent() && !closingInPlaceEditor && !inPlaceEditorRow.isFocusWithin()) {
                         closeInPlaceEditor(true);
                     }
                 });
@@ -282,7 +282,7 @@ public class AllFieldsTab extends FieldsEditorTab {
         if (editors.containsKey(event.getField()) && StringUtil.isBlank(event.getNewValue())) {
             userAddedFields.add(event.getField());
         }
-        if (inPlaceEditingField != null) {
+        if (inPlaceEditingField.isPresent()) {
             // Defer structural rebuilds while the overlay editor is open (no focus
             // theft); the flow still re-renders so the edited segment's text follows
             // the typing live. The deferred check runs in closeInPlaceEditor.
@@ -300,7 +300,7 @@ public class AllFieldsTab extends FieldsEditorTab {
         if (!target.equals(editors.keySet()) || !coveredWithCitationKey(segments).equals(coveredByPreview)) {
             rebuildPanel(activeDatabaseContext(), entry);
         } else {
-            previewFlow.render(segments, null, this::onSegmentClicked);
+            previewFlow.render(segments, Optional.empty(), this::onSegmentClicked);
             renderHeaderRow(entry);
         }
     }
@@ -334,21 +334,23 @@ public class AllFieldsTab extends FieldsEditorTab {
             }
         });
 
-        Label keyLabel;
-        Optional<String> citationKey = entry.getCitationKey().filter(key -> !key.isBlank());
-        if (citationKey.isPresent()) {
-            keyLabel = new Label(citationKey.get());
-            keyLabel.getStyleClass().add("semantic-preview-citation-key");
-        } else {
-            keyLabel = new Label("{{" + FieldTextMapper.getDisplayName(InternalField.KEY_FIELD) + "}}");
-            keyLabel.getStyleClass().add("semantic-preview-citation-key-missing");
-        }
-        if (InternalField.KEY_FIELD.equals(inPlaceEditingField)) {
+        Label keyLabel = entry.getCitationKey()
+                              .filter(StringUtil::isNotBlank)
+                              .map(key -> {
+                                  Label label = new Label(key);
+                                  label.getStyleClass().add("semantic-preview-citation-key");
+                                  return label;
+                              })
+                              .orElseGet(() -> {
+                                  Label label = new Label("{{" + FieldTextMapper.getDisplayName(InternalField.KEY_FIELD) + "}}");
+                                  label.getStyleClass().add("semantic-preview-citation-key-missing");
+                                  return label;
+                              });
+        if (inPlaceEditingField.filter(InternalField.KEY_FIELD::equals).isPresent()) {
             keyLabel.getStyleClass().add("semantic-preview-editing");
         }
         keyLabel.setCursor(Cursor.HAND);
-        keyLabel.setTooltip(new Tooltip(Localization.lang("Edit") + ": "
-                + FieldTextMapper.getDisplayName(InternalField.KEY_FIELD)));
+        keyLabel.setTooltip(new Tooltip(FieldTextMapper.getDisplayName(InternalField.KEY_FIELD)));
         keyLabel.setOnMouseClicked(event -> {
             if (event.getButton() == MouseButton.PRIMARY) {
                 onSegmentClicked(InternalField.KEY_FIELD);
@@ -370,10 +372,9 @@ public class AllFieldsTab extends FieldsEditorTab {
     /// would wreck the line layout.)
     // [impl->req~entry-editor.main-tab.in-place-edit~1]
     private void onSegmentClicked(Field field) {
-        if (field.equals(inPlaceEditingField)) {
-            FieldEditorFX editor = editors.get(field);
-            if (editor != null) {
-                editor.focus();
+        if (inPlaceEditingField.filter(field::equals).isPresent()) {
+            if (editors.containsKey(field)) {
+                editors.get(field).focus();
             }
             return;
         }
@@ -385,26 +386,27 @@ public class AllFieldsTab extends FieldsEditorTab {
     }
 
     private void openInPlaceEditor(Field field) {
-        BibEntry entry = getCurrentEntry();
-        FieldEditorFX editor = editors.get(field);
-        if ((entry == null) || (editor == null)) {
+        if (!editors.containsKey(field)) {
             return;
         }
-        closeInPlaceEditor(true);
-        inPlaceEditingField = field;
-        inPlaceEditingPreviousValue = entry.getField(field);
+        Optional.ofNullable(getCurrentEntry()).ifPresent(entry -> {
+            closeInPlaceEditor(true);
+            FieldEditorFX editor = editors.get(field);
+            inPlaceEditingField = Optional.of(field);
+            inPlaceEditingPreviousValue = entry.getField(field);
 
-        Label label = new Label(FieldTextMapper.getDisplayName(field));
-        label.getStyleClass().add("semantic-preview-editor-label");
-        Node editorNode = editor.getNode();
-        HBox.setHgrow(editorNode, Priority.ALWAYS);
-        inPlaceEditorRow.getChildren().setAll(label, editorNode);
-        int flowIndex = listContainer.getChildren().indexOf(previewFlow);
-        listContainer.getChildren().add(flowIndex + 1, inPlaceEditorRow);
+            Label label = new Label(FieldTextMapper.getDisplayName(field));
+            label.getStyleClass().add("semantic-preview-editor-label");
+            Node editorNode = editor.getNode();
+            HBox.setHgrow(editorNode, Priority.ALWAYS);
+            inPlaceEditorRow.getChildren().setAll(label, editorNode);
+            int flowIndex = listContainer.getChildren().indexOf(previewFlow);
+            listContainer.getChildren().add(flowIndex + 1, inPlaceEditorRow);
 
-        previewFlow.render(computeSegments(entry), field, this::onSegmentClicked);
-        renderHeaderRow(entry);
-        Platform.runLater(editor::focus);
+            previewFlow.render(computeSegments(entry), inPlaceEditingField, this::onSegmentClicked);
+            renderHeaderRow(entry);
+            Platform.runLater(editor::focus);
+        });
     }
 
     /// Jump-to-field and the focus key bindings route preview-covered fields to the
@@ -423,30 +425,28 @@ public class AllFieldsTab extends FieldsEditorTab {
     /// runs: rebuild if the shown/covered set changed while editing, else just drop
     /// the highlight.
     private void closeInPlaceEditor(boolean keepValue) {
-        if (inPlaceEditingField == null) {
+        if (inPlaceEditingField.isEmpty()) {
             return;
         }
         closingInPlaceEditor = true;
-        Field field = inPlaceEditingField;
-        BibEntry entry = getCurrentEntry();
+        Field field = inPlaceEditingField.orElseThrow();
+        Optional<BibEntry> entry = Optional.ofNullable(getCurrentEntry());
         try {
-            if (!keepValue && (entry != null)) {
-                inPlaceEditingPreviousValue.ifPresentOrElse(
-                        value -> entry.setField(field, value),
-                        () -> entry.clearField(field));
+            if (!keepValue) {
+                entry.ifPresent(current -> inPlaceEditingPreviousValue.ifPresentOrElse(
+                        value -> current.setField(field, value),
+                        () -> current.clearField(field)));
             }
         } finally {
             discardInPlaceEditor();
             closingInPlaceEditor = false;
         }
-        if (entry != null) {
-            refreshAfterChange(entry);
-        }
+        entry.ifPresent(this::refreshAfterChange);
     }
 
     /// Drops the overlay editor without value restore or refresh (entry switch, rebind).
     private void discardInPlaceEditor() {
-        inPlaceEditingField = null;
+        inPlaceEditingField = Optional.empty();
         inPlaceEditingPreviousValue = Optional.empty();
         listContainer.getChildren().remove(inPlaceEditorRow);
         inPlaceEditorRow.getChildren().clear();

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -17,11 +17,14 @@ import javax.swing.undo.UndoManager;
 
 import javafx.application.Platform;
 import javafx.geometry.Pos;
+import javafx.geometry.Side;
 import javafx.geometry.VPos;
+import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
@@ -30,6 +33,7 @@ import javafx.scene.control.TitledPane;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseButton;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
@@ -41,6 +45,7 @@ import javafx.scene.layout.VBox;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.fieldeditors.FieldEditorFX;
 import org.jabref.gui.icon.IconTheme;
+import org.jabref.gui.menus.ChangeEntryTypeMenu;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.preview.PreviewPanel;
 import org.jabref.gui.undo.RedoAction;
@@ -90,6 +95,7 @@ public class AllFieldsTab extends FieldsEditorTab {
 
     private final BibEntryTypesManager entryTypesManager;
     private final GuiPreferences guiPreferences;
+    private final UndoManager undoManager;
 
     /// The current user's personal comment field (derived from the default-owner preference).
     private final UserSpecificCommentField userSpecificCommentField;
@@ -134,6 +140,10 @@ public class AllFieldsTab extends FieldsEditorTab {
     /// Overlay row hosting the in-place editor (field label + bound editor node).
     private final HBox inPlaceEditorRow = new HBox();
 
+    /// Header line above the preview: "@type · citationkey"; the key is click-to-edit,
+    /// the type opens the change-entry-type menu.
+    private final HBox headerRow = new HBox();
+
     /// Guards the focus-loss listener while the editor is being closed programmatically.
     private boolean closingInPlaceEditor;
 
@@ -158,6 +168,7 @@ public class AllFieldsTab extends FieldsEditorTab {
 
         this.entryTypesManager = entryTypesManager;
         this.guiPreferences = preferences;
+        this.undoManager = undoManager;
         String defaultOwner = NON_ALPHANUMERIC.matcher(
                 preferences.getOwnerPreferences().getDefaultOwner().toLowerCase(Locale.ROOT)).replaceAll("-");
         this.userSpecificCommentField = new UserSpecificCommentField(defaultOwner);
@@ -166,6 +177,9 @@ public class AllFieldsTab extends FieldsEditorTab {
         setText(EntryEditorTabModel.BuiltIn.ALL_FIELDS.displayName());
         setTooltip(new Tooltip(Localization.lang("Show all fields")));
         setGraphic(IconTheme.JabRefIcons.REQUIRED.getGraphicNode());
+
+        headerRow.getStyleClass().add("semantic-preview-header");
+        headerRow.setAlignment(Pos.CENTER_LEFT);
 
         inPlaceEditorRow.getStyleClass().add("semantic-preview-editor-row");
         inPlaceEditorRow.setAlignment(Pos.CENTER_LEFT);
@@ -279,20 +293,74 @@ public class AllFieldsTab extends FieldsEditorTab {
     }
 
     /// Rebuilds when the shown or preview-covered field set changed; otherwise only
-    /// re-renders the flow text.
+    /// re-renders the flow text and the header line.
     private void refreshAfterChange(BibEntry entry) {
         SequencedSet<Field> target = determineFieldsToShow(entry);
         CitationSegments segments = computeSegments(entry);
-        if (!target.equals(editors.keySet()) || !segments.coveredFields().equals(coveredByPreview)) {
+        if (!target.equals(editors.keySet()) || !coveredWithCitationKey(segments).equals(coveredByPreview)) {
             rebuildPanel(activeDatabaseContext(), entry);
         } else {
             previewFlow.render(segments, null, this::onSegmentClicked);
+            renderHeaderRow(entry);
         }
     }
 
     private CitationSegments computeSegments(BibEntry entry) {
         return CitationSegments.of(entry, entryTypesManager.enrich(entry.getType(), getDatabaseMode()));
     }
+
+    /// The preview also represents the citation key (in the header line above the flow),
+    /// so it counts as covered for the no-duplication rule.
+    private SequencedSet<Field> coveredWithCitationKey(CitationSegments segments) {
+        SequencedSet<Field> covered = new LinkedHashSet<>(segments.coveredFields());
+        covered.add(InternalField.KEY_FIELD);
+        return covered;
+    }
+
+    // region header row
+
+    /// "@type · citationkey": the type opens the change-entry-type menu, the key opens
+    /// its in-place editor (CitationKeyEditor including the generate button).
+    private void renderHeaderRow(BibEntry entry) {
+        Label typeLabel = new Label("@" + entry.getType().getName());
+        typeLabel.getStyleClass().add("semantic-preview-entry-type");
+        typeLabel.setCursor(Cursor.HAND);
+        typeLabel.setTooltip(new Tooltip(Localization.lang("Change entry type")));
+        typeLabel.setOnMouseClicked(event -> {
+            if (event.getButton() == MouseButton.PRIMARY) {
+                ContextMenu typeMenu = new ChangeEntryTypeMenu(
+                        List.of(entry), activeDatabaseContext(), undoManager, entryTypesManager).asContextMenu();
+                typeMenu.show(typeLabel, Side.BOTTOM, 0, 0);
+            }
+        });
+
+        Label keyLabel;
+        Optional<String> citationKey = entry.getCitationKey().filter(key -> !key.isBlank());
+        if (citationKey.isPresent()) {
+            keyLabel = new Label(citationKey.get());
+            keyLabel.getStyleClass().add("semantic-preview-citation-key");
+        } else {
+            keyLabel = new Label("{{" + FieldTextMapper.getDisplayName(InternalField.KEY_FIELD) + "}}");
+            keyLabel.getStyleClass().add("semantic-preview-citation-key-missing");
+        }
+        if (InternalField.KEY_FIELD.equals(inPlaceEditingField)) {
+            keyLabel.getStyleClass().add("semantic-preview-editing");
+        }
+        keyLabel.setCursor(Cursor.HAND);
+        keyLabel.setTooltip(new Tooltip(Localization.lang("Edit") + ": "
+                + FieldTextMapper.getDisplayName(InternalField.KEY_FIELD)));
+        keyLabel.setOnMouseClicked(event -> {
+            if (event.getButton() == MouseButton.PRIMARY) {
+                onSegmentClicked(InternalField.KEY_FIELD);
+            }
+        });
+
+        Label separator = new Label("·");
+        separator.getStyleClass().add("semantic-preview-header-separator");
+        headerRow.getChildren().setAll(typeLabel, separator, keyLabel);
+    }
+
+    // endregion
 
     // region in-place editing
 
@@ -335,7 +403,19 @@ public class AllFieldsTab extends FieldsEditorTab {
         listContainer.getChildren().add(flowIndex + 1, inPlaceEditorRow);
 
         previewFlow.render(computeSegments(entry), field, this::onSegmentClicked);
+        renderHeaderRow(entry);
         Platform.runLater(editor::focus);
+    }
+
+    /// Jump-to-field and the focus key bindings route preview-covered fields to the
+    /// in-place editor; everything else focuses its regular editor row.
+    @Override
+    public void requestFocus(Field fieldName) {
+        if (coveredByPreview.contains(fieldName) && editors.containsKey(fieldName)) {
+            openInPlaceEditor(fieldName);
+            return;
+        }
+        super.requestFocus(fieldName);
     }
 
     /// Closes the overlay editor. `keepValue = false` (Esc) restores the field to the
@@ -390,8 +470,9 @@ public class AllFieldsTab extends FieldsEditorTab {
         }
 
         CitationSegments segments = computeSegments(entry);
-        coveredByPreview = segments.coveredFields();
+        coveredByPreview = coveredWithCitationKey(segments);
         previewFlow.render(segments, inPlaceEditingField, this::onSegmentClicked);
+        renderHeaderRow(entry);
 
         Map<FieldListSections.SectionType, SequencedSet<Field>> buckets =
                 new EnumMap<>(FieldListSections.SectionType.class);
@@ -411,7 +492,7 @@ public class AllFieldsTab extends FieldsEditorTab {
         }
         addFieldRows(gridPane, buckets.get(FieldListSections.SectionType.MAIN), labelForField);
 
-        listContainer.getChildren().setAll(previewFlow, gridPane, createMainChipBar(bibDatabaseContext, entry));
+        listContainer.getChildren().setAll(headerRow, previewFlow, gridPane, createMainChipBar(bibDatabaseContext, entry));
         for (FieldListSections.SectionType type : FieldListSections.SectionType.values()) {
             if (type == FieldListSections.SectionType.MAIN) {
                 continue;

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -28,6 +28,8 @@ import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TitledPane;
 import javafx.scene.control.Tooltip;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
@@ -122,6 +124,19 @@ public class AllFieldsTab extends FieldsEditorTab {
     /// precedence, a field never appears twice (no-duplication rule).
     private SequencedSet<Field> coveredByPreview = new LinkedHashSet<>();
 
+    /// In-place editing: the preview-covered field currently edited in the overlay row
+    /// directly beneath the flow; null when no in-place editor is open.
+    private @Nullable Field inPlaceEditingField;
+
+    /// The field's value when the in-place editor was opened; Esc restores it.
+    private Optional<String> inPlaceEditingPreviousValue = Optional.empty();
+
+    /// Overlay row hosting the in-place editor (field label + bound editor node).
+    private final HBox inPlaceEditorRow = new HBox();
+
+    /// Guards the focus-loss listener while the editor is being closed programmatically.
+    private boolean closingInPlaceEditor;
+
     public AllFieldsTab(UndoManager undoManager,
                         UndoAction undoAction,
                         RedoAction redoAction,
@@ -151,6 +166,29 @@ public class AllFieldsTab extends FieldsEditorTab {
         setText(EntryEditorTabModel.BuiltIn.ALL_FIELDS.displayName());
         setTooltip(new Tooltip(Localization.lang("Show all fields")));
         setGraphic(IconTheme.JabRefIcons.REQUIRED.getGraphicNode());
+
+        inPlaceEditorRow.getStyleClass().add("semantic-preview-editor-row");
+        inPlaceEditorRow.setAlignment(Pos.CENTER_LEFT);
+        inPlaceEditorRow.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                closeInPlaceEditor(true);
+                event.consume();
+            } else if (event.getCode() == KeyCode.ESCAPE) {
+                closeInPlaceEditor(false);
+                event.consume();
+            }
+        });
+        // Focus leaving the overlay row closes the editor (value is already written
+        // through); runLater so focus transfers inside the row do not close it.
+        inPlaceEditorRow.focusWithinProperty().addListener((_, _, focused) -> {
+            if (!focused && (inPlaceEditingField != null) && !closingInPlaceEditor) {
+                Platform.runLater(() -> {
+                    if ((inPlaceEditingField != null) && !closingInPlaceEditor && !inPlaceEditorRow.isFocusWithin()) {
+                        closeInPlaceEditor(true);
+                    }
+                });
+            }
+        });
     }
 
     /// Order: citation key, required fields (entry-type order), set optional fields
@@ -199,6 +237,7 @@ public class AllFieldsTab extends FieldsEditorTab {
 
     @Override
     protected void bindToEntry(BibEntry entry) {
+        discardInPlaceEditor();
         if (subscribedEntry.filter(current -> current == entry).isEmpty()) {
             subscribedEntry.ifPresent(previous -> previous.unregisterListener(this));
             entry.registerListener(this);
@@ -229,13 +268,25 @@ public class AllFieldsTab extends FieldsEditorTab {
         if (editors.containsKey(event.getField()) && StringUtil.isBlank(event.getNewValue())) {
             userAddedFields.add(event.getField());
         }
+        if (inPlaceEditingField != null) {
+            // Defer structural rebuilds while the overlay editor is open (no focus
+            // theft); the flow still re-renders so the edited segment's text follows
+            // the typing live. The deferred check runs in closeInPlaceEditor.
+            previewFlow.render(computeSegments(entry), inPlaceEditingField, this::onSegmentClicked);
+            return;
+        }
+        refreshAfterChange(entry);
+    }
+
+    /// Rebuilds when the shown or preview-covered field set changed; otherwise only
+    /// re-renders the flow text.
+    private void refreshAfterChange(BibEntry entry) {
         SequencedSet<Field> target = determineFieldsToShow(entry);
         CitationSegments segments = computeSegments(entry);
         if (!target.equals(editors.keySet()) || !segments.coveredFields().equals(coveredByPreview)) {
             rebuildPanel(activeDatabaseContext(), entry);
         } else {
-            // Same layout, possibly new values: refresh the preview text only.
-            previewFlow.render(segments, this::onSegmentClicked);
+            previewFlow.render(segments, null, this::onSegmentClicked);
         }
     }
 
@@ -243,11 +294,85 @@ public class AllFieldsTab extends FieldsEditorTab {
         return CitationSegments.of(entry, entryTypesManager.enrich(entry.getType(), getDatabaseMode()));
     }
 
-    /// Clicking a preview segment will open the field's editor in place (next step);
-    /// for now it focuses the field's editor if one is shown below.
+    // region in-place editing
+
+    /// Clicking a preview segment opens the field's bound editor in the overlay row
+    /// directly beneath the flow; the segment gets a highlight. (A literal swap inside
+    /// the TextFlow is not feasible: field editors are compound HBox controls that
+    /// would wreck the line layout.)
+    // [impl->req~entry-editor.main-tab.in-place-edit~1]
     private void onSegmentClicked(Field field) {
-        requestFocus(field);
+        if (field.equals(inPlaceEditingField)) {
+            FieldEditorFX editor = editors.get(field);
+            if (editor != null) {
+                editor.focus();
+            }
+            return;
+        }
+        if (!coveredByPreview.contains(field)) {
+            requestFocus(field);
+            return;
+        }
+        openInPlaceEditor(field);
     }
+
+    private void openInPlaceEditor(Field field) {
+        BibEntry entry = getCurrentEntry();
+        FieldEditorFX editor = editors.get(field);
+        if ((entry == null) || (editor == null)) {
+            return;
+        }
+        closeInPlaceEditor(true);
+        inPlaceEditingField = field;
+        inPlaceEditingPreviousValue = entry.getField(field);
+
+        Label label = new Label(FieldTextMapper.getDisplayName(field));
+        label.getStyleClass().add("semantic-preview-editor-label");
+        Node editorNode = editor.getNode();
+        HBox.setHgrow(editorNode, Priority.ALWAYS);
+        inPlaceEditorRow.getChildren().setAll(label, editorNode);
+        int flowIndex = listContainer.getChildren().indexOf(previewFlow);
+        listContainer.getChildren().add(flowIndex + 1, inPlaceEditorRow);
+
+        previewFlow.render(computeSegments(entry), field, this::onSegmentClicked);
+        Platform.runLater(editor::focus);
+    }
+
+    /// Closes the overlay editor. `keepValue = false` (Esc) restores the field to the
+    /// value it had when the editor was opened. Afterwards the deferred layout check
+    /// runs: rebuild if the shown/covered set changed while editing, else just drop
+    /// the highlight.
+    private void closeInPlaceEditor(boolean keepValue) {
+        if (inPlaceEditingField == null) {
+            return;
+        }
+        closingInPlaceEditor = true;
+        Field field = inPlaceEditingField;
+        BibEntry entry = getCurrentEntry();
+        try {
+            if (!keepValue && (entry != null)) {
+                inPlaceEditingPreviousValue.ifPresentOrElse(
+                        value -> entry.setField(field, value),
+                        () -> entry.clearField(field));
+            }
+        } finally {
+            discardInPlaceEditor();
+            closingInPlaceEditor = false;
+        }
+        if (entry != null) {
+            refreshAfterChange(entry);
+        }
+    }
+
+    /// Drops the overlay editor without value restore or refresh (entry switch, rebind).
+    private void discardInPlaceEditor() {
+        inPlaceEditingField = null;
+        inPlaceEditingPreviousValue = Optional.empty();
+        listContainer.getChildren().remove(inPlaceEditorRow);
+        inPlaceEditorRow.getChildren().clear();
+    }
+
+    // endregion
 
     /// Main fields as a grid with natural row heights, then the optional-field chip bar,
     /// then the always-present collapsible sections (identifiers / files & links /
@@ -266,7 +391,7 @@ public class AllFieldsTab extends FieldsEditorTab {
 
         CitationSegments segments = computeSegments(entry);
         coveredByPreview = segments.coveredFields();
-        previewFlow.render(segments, this::onSegmentClicked);
+        previewFlow.render(segments, inPlaceEditingField, this::onSegmentClicked);
 
         Map<FieldListSections.SectionType, SequencedSet<Field>> buckets =
                 new EnumMap<>(FieldListSections.SectionType.class);
@@ -453,6 +578,7 @@ public class AllFieldsTab extends FieldsEditorTab {
     /// field if necessary) and focuses it.
     // [impl->req~entry-editor.main-tab.add-chips~1]
     private void showFieldEditor(BibDatabaseContext bibDatabaseContext, BibEntry entry, Field field) {
+        closeInPlaceEditor(true);
         userAddedFields.add(field);
         rebuildPanel(bibDatabaseContext, entry);
         Platform.runLater(() -> requestFocus(field));

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -110,8 +110,17 @@ public class AllFieldsTab extends FieldsEditorTab {
     /// when fields are set/unset from outside, e.g. Source tab, fetchers, undo).
     private Optional<BibEntry> subscribedEntry = Optional.empty();
 
-    /// Scroll content: main grid + chip bar + section panes + free-form add row.
+    /// Scroll content: semantic preview + main grid + chip bar + section panes +
+    /// free-form add row.
     private final VBox listContainer = new VBox();
+
+    /// The editable semantic preview at the top of the tab (concept #2, issue #12711).
+    private final SemanticPreviewFlow previewFlow = new SemanticPreviewFlow();
+
+    /// Fields currently represented in the semantic preview (as value or placeholder).
+    /// They are subtracted from all rows and chip lists below — the preview takes
+    /// precedence, a field never appears twice (no-duplication rule).
+    private SequencedSet<Field> coveredByPreview = new LinkedHashSet<>();
 
     public AllFieldsTab(UndoManager undoManager,
                         UndoAction undoAction,
@@ -221,9 +230,23 @@ public class AllFieldsTab extends FieldsEditorTab {
             userAddedFields.add(event.getField());
         }
         SequencedSet<Field> target = determineFieldsToShow(entry);
-        if (!target.equals(editors.keySet())) {
+        CitationSegments segments = computeSegments(entry);
+        if (!target.equals(editors.keySet()) || !segments.coveredFields().equals(coveredByPreview)) {
             rebuildPanel(activeDatabaseContext(), entry);
+        } else {
+            // Same layout, possibly new values: refresh the preview text only.
+            previewFlow.render(segments, this::onSegmentClicked);
         }
+    }
+
+    private CitationSegments computeSegments(BibEntry entry) {
+        return CitationSegments.of(entry, entryTypesManager.enrich(entry.getType(), getDatabaseMode()));
+    }
+
+    /// Clicking a preview segment will open the field's editor in place (next step);
+    /// for now it focuses the field's editor if one is shown below.
+    private void onSegmentClicked(Field field) {
+        requestFocus(field);
     }
 
     /// Main fields as a grid with natural row heights, then the optional-field chip bar,
@@ -241,12 +264,21 @@ public class AllFieldsTab extends FieldsEditorTab {
             labelIndex++;
         }
 
+        CitationSegments segments = computeSegments(entry);
+        coveredByPreview = segments.coveredFields();
+        previewFlow.render(segments, this::onSegmentClicked);
+
         Map<FieldListSections.SectionType, SequencedSet<Field>> buckets =
                 new EnumMap<>(FieldListSections.SectionType.class);
         for (FieldListSections.SectionType type : FieldListSections.SectionType.values()) {
             buckets.put(type, new LinkedHashSet<>());
         }
-        editors.keySet().forEach(field -> buckets.get(FieldListSections.sectionOf(field)).add(field));
+        // [impl->req~entry-editor.main-tab.no-duplication~1]
+        Set<Field> suppressedAlternatives = unsetAlternativesOfSatisfiedGroups(entry);
+        editors.keySet().stream()
+               .filter(field -> !coveredByPreview.contains(field))
+               .filter(field -> !suppressedAlternatives.contains(field))
+               .forEach(field -> buckets.get(FieldListSections.sectionOf(field)).add(field));
 
         // Main section rows go into the (already cleared) inherited gridPane
         if (!gridPane.getStyleClass().contains("all-fields-list")) {
@@ -254,7 +286,7 @@ public class AllFieldsTab extends FieldsEditorTab {
         }
         addFieldRows(gridPane, buckets.get(FieldListSections.SectionType.MAIN), labelForField);
 
-        listContainer.getChildren().setAll(gridPane, createMainChipBar(bibDatabaseContext, entry));
+        listContainer.getChildren().setAll(previewFlow, gridPane, createMainChipBar(bibDatabaseContext, entry));
         for (FieldListSections.SectionType type : FieldListSections.SectionType.values()) {
             if (type == FieldListSections.SectionType.MAIN) {
                 continue;
@@ -311,7 +343,7 @@ public class AllFieldsTab extends FieldsEditorTab {
             content.getChildren().add(sectionGrid);
         }
 
-        SequencedSet<Field> chipFields = FieldListSections.subtract(sectionMemberFields(type), editors.keySet());
+        SequencedSet<Field> chipFields = FieldListSections.subtract(sectionMemberFields(type), visibleFields());
         if (!chipFields.isEmpty()) {
             FlowPane chips = new FlowPane();
             chips.getStyleClass().add("all-fields-add-chips");
@@ -357,7 +389,7 @@ public class AllFieldsTab extends FieldsEditorTab {
         chips.getStyleClass().add("all-fields-add-chips");
 
         entryTypesManager.enrich(entry.getType(), mode).ifPresent(entryType -> {
-            List<Field> shown = List.copyOf(editors.keySet());
+            Set<Field> shown = visibleFields();
             FieldListSections.subtract(entryType.getImportantOptionalFields(), shown).stream()
                              .filter(field -> FieldListSections.sectionOf(field) == FieldListSections.SectionType.MAIN)
                              .forEach(field -> chips.getChildren().add(createAddChip(bibDatabaseContext, entry, field)));
@@ -431,6 +463,39 @@ public class AllFieldsTab extends FieldsEditorTab {
     }
 
     // endregion
+
+    /// Unset members of required [OrFields] groups whose requirement is already satisfied
+    /// by another (set) member — e.g. the empty Author row of an editor-only `@book`.
+    /// They are alternatives, not missing data, so they get no empty editor row below the
+    /// preview. Explicitly user-added fields stay visible (free-form add is the escape
+    /// hatch to fill the other alternative anyway).
+    private Set<Field> unsetAlternativesOfSatisfiedGroups(BibEntry entry) {
+        Set<Field> result = new LinkedHashSet<>();
+        entryTypesManager.enrich(entry.getType(), getDatabaseMode()).ifPresent(entryType -> {
+            for (OrFields group : entryType.getRequiredFields()) {
+                if (group.hasExactlyOne()) {
+                    continue;
+                }
+                boolean satisfied = group.getFields().stream()
+                                         .anyMatch(field -> entry.getField(field).filter(value -> !value.isBlank()).isPresent());
+                if (satisfied) {
+                    group.getFields().stream()
+                         .filter(field -> entry.getField(field).filter(value -> !value.isBlank()).isEmpty())
+                         .filter(field -> !userAddedFields.contains(field))
+                         .forEach(result::add);
+                }
+            }
+        });
+        return result;
+    }
+
+    /// Fields already visible somewhere on this tab: as an editor row or as a
+    /// segment (value/placeholder) of the semantic preview.
+    private Set<Field> visibleFields() {
+        Set<Field> visible = new LinkedHashSet<>(editors.keySet());
+        visible.addAll(coveredByPreview);
+        return visible;
+    }
 
     private BibDatabaseMode getDatabaseMode() {
         return stateManager.getActiveDatabase()

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/CitationSegments.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/CitationSegments.java
@@ -6,7 +6,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.SequencedSet;
+import java.util.regex.Pattern;
 
+import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.entry.AuthorList;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
@@ -39,6 +41,9 @@ public record CitationSegments(List<Token> tokens, SequencedSet<Field> coveredFi
     /// Rendered field values are capped at this many characters (long values such as
     /// abstracts are not part of the template vocabulary, but titles can get long too).
     static final int VALUE_DISPLAY_MAX_LENGTH = 250;
+
+    /// Runs of whitespace (including line breaks) collapse to one space for display.
+    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
     /// Visual style of a [FieldToken]; standalone titles and venue names render italic.
     public enum SegmentStyle {
@@ -211,28 +216,23 @@ public record CitationSegments(List<Token> tokens, SequencedSet<Field> coveredFi
         /// requirement (its [OrFields] group) is entirely unmet → [PlaceholderToken];
         /// otherwise nothing. The prefix literal is emitted only alongside a token.
         private void slot(String prefix, SegmentStyle style, Field... candidates) {
-            Optional<Field> setField = firstSet(candidates);
-            if (setField.isPresent()) {
-                emitField(prefix, style, setField.get(), displayValue(setField.get()));
-                return;
-            }
-            firstUnmetRequired(candidates).ifPresent(field -> emitPlaceholder(prefix, field));
+            firstSet(candidates).ifPresentOrElse(
+                    field -> emitField(prefix, style, field, displayValue(field)),
+                    () -> firstUnmetRequired(candidates).ifPresent(field -> emitPlaceholder(prefix, field)));
         }
 
         /// Author/editor slot: display via [AuthorList] ("First Last and First Last");
         /// an editor-resolved slot is marked with " (Eds.)".
         private void personSlot() {
-            Optional<Field> setField = firstSet(StandardField.AUTHOR, StandardField.EDITOR);
-            if (setField.isPresent()) {
-                Field field = setField.get();
-                emitField("", SegmentStyle.PLAIN, field, displayPersons(field));
-                if (field == StandardField.EDITOR) {
-                    tokens.add(new TextToken(" (Eds.)"));
-                }
-                return;
-            }
-            firstUnmetRequired(StandardField.AUTHOR, StandardField.EDITOR)
-                    .ifPresent(field -> emitPlaceholder("", field));
+            firstSet(StandardField.AUTHOR, StandardField.EDITOR).ifPresentOrElse(
+                    field -> {
+                        emitField("", SegmentStyle.PLAIN, field, displayPersons(field));
+                        if (field == StandardField.EDITOR) {
+                            tokens.add(new TextToken(" (Eds.)"));
+                        }
+                    },
+                    () -> firstUnmetRequired(StandardField.AUTHOR, StandardField.EDITOR)
+                            .ifPresent(field -> emitPlaceholder("", field)));
         }
 
         /// Year with date alias: the set one of year/date, else the required one.
@@ -332,7 +332,7 @@ public record CitationSegments(List<Token> tokens, SequencedSet<Field> coveredFi
         // region field access and display
 
         private boolean isSet(Field field) {
-            return entry.getField(field).filter(value -> !value.isBlank()).isPresent();
+            return entry.getField(field).filter(StringUtil::isNotBlank).isPresent();
         }
 
         private Optional<Field> firstSet(Field... candidates) {
@@ -350,9 +350,9 @@ public record CitationSegments(List<Token> tokens, SequencedSet<Field> coveredFi
         }
 
         private String displayValue(Field field) {
-            String value = LatexToUnicodeAdapter.format(entry.getField(field).orElse(""))
-                                                .replaceAll("\\s+", " ")
-                                                .trim();
+            String value = WHITESPACE.matcher(LatexToUnicodeAdapter.format(entry.getField(field).orElse("")))
+                                     .replaceAll(" ")
+                                     .trim();
             if (field == StandardField.PAGES) {
                 value = value.replace("--", "–");
             }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/CitationSegments.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/CitationSegments.java
@@ -1,0 +1,373 @@
+package org.jabref.gui.entryeditor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.SequencedSet;
+
+import org.jabref.model.entry.AuthorList;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryType;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.OrFields;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.EntryType;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.strings.LatexToUnicodeAdapter;
+
+import org.jspecify.annotations.NullMarked;
+
+/// The semantic preview of an entry as an ordered token list (issue #12711, concept #2):
+/// a citation-like rendering ("Author. Title. Journal, 12(3):45–67, 2020.") where every
+/// field value is its own [FieldToken] (clickable → in-place edit in the [AllFieldsTab])
+/// and every required-but-unset field is a [PlaceholderToken] (rendered as `{{Field}}`).
+///
+/// Plain Java (no JavaFX) so templates and punctuation logic are unit-testable.
+///
+/// [#coveredFields()] lists every field represented in the preview (set fields rendered
+/// as text plus required fields rendered as placeholders). The tab subtracts these from
+/// all other chip lists and editor rows — the preview takes precedence, a field never
+/// appears twice ("no duplication" rule).
+///
+/// A required field that is not part of the template vocabulary shows up as a trailing
+/// placeholder while unset; once set, it is no longer covered and moves to its regular
+/// place below the preview (section or "more fields" row).
+@NullMarked
+public record CitationSegments(List<Token> tokens, SequencedSet<Field> coveredFields) {
+    /// Rendered field values are capped at this many characters (long values such as
+    /// abstracts are not part of the template vocabulary, but titles can get long too).
+    static final int VALUE_DISPLAY_MAX_LENGTH = 250;
+
+    /// Visual style of a [FieldToken]; standalone titles and venue names render italic.
+    public enum SegmentStyle {
+        PLAIN,
+        ITALIC
+    }
+
+    public sealed interface Token permits TextToken, FieldToken, PlaceholderToken {
+    }
+
+    /// Punctuation or literal text between field segments; not clickable.
+    public record TextToken(String text) implements Token {
+    }
+
+    /// A set field with its display text; clickable → in-place edit.
+    public record FieldToken(Field field, String displayText, SegmentStyle style) implements Token {
+    }
+
+    /// A required-but-unset field; rendered as `{{Field}}`; clickable → in-place edit.
+    public record PlaceholderToken(Field field) implements Token {
+    }
+
+    // [impl->req~entry-editor.main-tab.semantic-preview~1]
+    public static CitationSegments of(BibEntry entry, Optional<BibEntryType> entryType) {
+        SequencedSet<OrFields> requiredFields =
+                entryType.map(BibEntryType::getRequiredFields).orElseGet(LinkedHashSet::new);
+        Builder builder = new Builder(entry, requiredFields);
+
+        EntryType type = entry.getType();
+        if (type instanceof StandardEntryType standardType) {
+            switch (standardType) {
+                case Article,
+                     SuppPeriodical ->
+                        article(builder);
+                case Book,
+                     MvBook,
+                     InBook,
+                     BookInBook,
+                     SuppBook,
+                     Booklet,
+                     Collection,
+                     MvCollection,
+                     Proceedings,
+                     MvProceedings,
+                     Reference,
+                     MvReference ->
+                        book(builder);
+                case InProceedings,
+                     Conference,
+                     InCollection,
+                     SuppCollection,
+                     InReference ->
+                        partOfCollection(builder);
+                case PhdThesis,
+                     MastersThesis,
+                     Thesis,
+                     TechReport,
+                     Report ->
+                        thesisOrReport(builder);
+                default ->
+                        fallback(builder);
+            }
+        } else {
+            fallback(builder);
+        }
+
+        builder.trailingRequiredPlaceholders();
+        builder.finish();
+        return new CitationSegments(List.copyOf(builder.tokens), builder.covered);
+    }
+
+    // region templates
+
+    /// Authors. Title. *Journal*, 12(3):45–67, 2020.
+    private static void article(Builder b) {
+        b.sentence();
+        b.personSlot();
+        b.sentence();
+        b.slot("", SegmentStyle.PLAIN, StandardField.TITLE);
+        b.sentence();
+        b.slot("", SegmentStyle.ITALIC, StandardField.JOURNAL, StandardField.JOURNALTITLE);
+        b.volumeNumberPages();
+        b.yearSlot();
+    }
+
+    /// Authors. *Title*. Publisher, 2020.
+    private static void book(Builder b) {
+        b.sentence();
+        b.personSlot();
+        b.sentence();
+        b.slot("", SegmentStyle.ITALIC, StandardField.TITLE);
+        b.sentence();
+        b.slot("", SegmentStyle.PLAIN, StandardField.PUBLISHER);
+        b.yearSlot();
+    }
+
+    /// Authors. Title. In *Booktitle*, pages 45–67, Publisher, 2020.
+    private static void partOfCollection(Builder b) {
+        b.sentence();
+        b.personSlot();
+        b.sentence();
+        b.slot("", SegmentStyle.PLAIN, StandardField.TITLE);
+        b.sentence();
+        b.slot("In ", SegmentStyle.ITALIC, StandardField.BOOKTITLE);
+        b.slot("pages ", SegmentStyle.PLAIN, StandardField.PAGES);
+        b.slot("", SegmentStyle.PLAIN, StandardField.PUBLISHER);
+        b.yearSlot();
+    }
+
+    /// Author. *Title*. Type, School/Institution, number 42, 2020.
+    /// Covers bibtex (phdthesis/mastersthesis/techreport: type optional) and biblatex
+    /// (thesis/report: type required → placeholder when unset).
+    private static void thesisOrReport(Builder b) {
+        b.sentence();
+        b.personSlot();
+        b.sentence();
+        b.slot("", SegmentStyle.ITALIC, StandardField.TITLE);
+        b.sentence();
+        b.slot("", SegmentStyle.PLAIN, StandardField.TYPE);
+        b.slot("", SegmentStyle.PLAIN, StandardField.SCHOOL, StandardField.INSTITUTION);
+        b.slot("number ", SegmentStyle.PLAIN, StandardField.NUMBER);
+        b.yearSlot();
+    }
+
+    /// Generic shape for misc and unknown/custom types; required fields outside the
+    /// vocabulary surface via [Builder#trailingRequiredPlaceholders()].
+    private static void fallback(Builder b) {
+        b.sentence();
+        b.personSlot();
+        b.sentence();
+        b.slot("", SegmentStyle.PLAIN, StandardField.TITLE);
+        b.sentence();
+        b.slot("", SegmentStyle.ITALIC, StandardField.JOURNAL, StandardField.JOURNALTITLE);
+        b.volumeNumberPages();
+        b.sentence();
+        b.slot("In ", SegmentStyle.ITALIC, StandardField.BOOKTITLE);
+        b.sentence();
+        b.slot("", SegmentStyle.PLAIN, StandardField.HOWPUBLISHED);
+        b.slot("", SegmentStyle.PLAIN,
+                StandardField.PUBLISHER, StandardField.ORGANIZATION, StandardField.SCHOOL, StandardField.INSTITUTION);
+        b.yearSlot();
+    }
+
+    // endregion
+
+    /// Accumulates tokens with citation punctuation: parts within a sentence are joined
+    /// by ", ", sentences by ". ", and a final "." closes the rendering. A slot emits
+    /// nothing when its field is neither set nor required — the surrounding punctuation
+    /// is suppressed with it.
+    private static final class Builder {
+
+        private final BibEntry entry;
+        private final SequencedSet<OrFields> requiredFields;
+        private final List<Token> tokens = new ArrayList<>();
+        private final SequencedSet<Field> covered = new LinkedHashSet<>();
+
+        private boolean sentenceHasContent;
+        private boolean anyContent;
+
+        private Builder(BibEntry entry, SequencedSet<OrFields> requiredFields) {
+            this.entry = entry;
+            this.requiredFields = requiredFields;
+        }
+
+        private void sentence() {
+            sentenceHasContent = false;
+        }
+
+        /// First set candidate → [FieldToken]; otherwise first candidate whose
+        /// requirement (its [OrFields] group) is entirely unmet → [PlaceholderToken];
+        /// otherwise nothing. The prefix literal is emitted only alongside a token.
+        private void slot(String prefix, SegmentStyle style, Field... candidates) {
+            Optional<Field> setField = firstSet(candidates);
+            if (setField.isPresent()) {
+                emitField(prefix, style, setField.get(), displayValue(setField.get()));
+                return;
+            }
+            firstUnmetRequired(candidates).ifPresent(field -> emitPlaceholder(prefix, field));
+        }
+
+        /// Author/editor slot: display via [AuthorList] ("First Last and First Last");
+        /// an editor-resolved slot is marked with " (Eds.)".
+        private void personSlot() {
+            Optional<Field> setField = firstSet(StandardField.AUTHOR, StandardField.EDITOR);
+            if (setField.isPresent()) {
+                Field field = setField.get();
+                emitField("", SegmentStyle.PLAIN, field, displayPersons(field));
+                if (field == StandardField.EDITOR) {
+                    tokens.add(new TextToken(" (Eds.)"));
+                }
+                return;
+            }
+            firstUnmetRequired(StandardField.AUTHOR, StandardField.EDITOR)
+                    .ifPresent(field -> emitPlaceholder("", field));
+        }
+
+        /// Year with date alias: the set one of year/date, else the required one.
+        private void yearSlot() {
+            slot("", SegmentStyle.PLAIN, StandardField.YEAR, StandardField.DATE);
+        }
+
+        /// Compact "12(3):45–67" when the volume is set; otherwise labeled stand-alone
+        /// parts ("number 3", "pages 45–67"). Emits set fields only (never required in
+        /// the standard types; custom requirements surface as trailing placeholders).
+        private void volumeNumberPages() {
+            if (isSet(StandardField.VOLUME)) {
+                emitField("", SegmentStyle.PLAIN, StandardField.VOLUME, displayValue(StandardField.VOLUME));
+                if (isSet(StandardField.NUMBER)) {
+                    appendRaw("(", StandardField.NUMBER, ")");
+                }
+                if (isSet(StandardField.PAGES)) {
+                    appendRaw(":", StandardField.PAGES, "");
+                }
+                return;
+            }
+            if (isSet(StandardField.NUMBER)) {
+                slot("number ", SegmentStyle.PLAIN, StandardField.NUMBER);
+            }
+            if (isSet(StandardField.PAGES)) {
+                slot("pages ", SegmentStyle.PLAIN, StandardField.PAGES);
+            }
+        }
+
+        /// Required fields (per [OrFields] group) that the template did not represent
+        /// and that are entirely unset — appended as a final placeholder sentence so
+        /// custom/exotic requirements (e.g. biblatex `type`, `url`) stay visible.
+        private void trailingRequiredPlaceholders() {
+            sentence();
+            requiredFields.stream()
+                          .filter(group -> group.getFields().stream()
+                                                .noneMatch(field -> covered.contains(field) || isSet(field)))
+                          .map(OrFields::getPrimary)
+                          .filter(field -> !covered.contains(field))
+                          .forEach(field -> emitPlaceholder("", field));
+        }
+
+        /// Closing period after the last rendered token.
+        private void finish() {
+            if (anyContent) {
+                tokens.add(new TextToken("."));
+            }
+        }
+
+        // region emission
+
+        private void emitField(String prefix, SegmentStyle style, Field field, String displayText) {
+            separator();
+            if (!prefix.isEmpty()) {
+                tokens.add(new TextToken(prefix));
+            }
+            tokens.add(new FieldToken(field, displayText, style));
+            markEmitted(field);
+        }
+
+        private void emitPlaceholder(String prefix, Field field) {
+            separator();
+            if (!prefix.isEmpty()) {
+                tokens.add(new TextToken(prefix));
+            }
+            tokens.add(new PlaceholderToken(field));
+            markEmitted(field);
+        }
+
+        /// Appends `open` + field + `close` directly after the previous token
+        /// (no separator), for composites like "12(3):45–67".
+        private void appendRaw(String open, Field field, String close) {
+            tokens.add(new TextToken(open));
+            tokens.add(new FieldToken(field, displayValue(field), SegmentStyle.PLAIN));
+            if (!close.isEmpty()) {
+                tokens.add(new TextToken(close));
+            }
+            markEmitted(field);
+        }
+
+        private void separator() {
+            if (sentenceHasContent) {
+                tokens.add(new TextToken(", "));
+            } else if (anyContent) {
+                tokens.add(new TextToken(". "));
+            }
+        }
+
+        private void markEmitted(Field field) {
+            covered.add(field);
+            sentenceHasContent = true;
+            anyContent = true;
+        }
+
+        // endregion
+
+        // region field access and display
+
+        private boolean isSet(Field field) {
+            return entry.getField(field).filter(value -> !value.isBlank()).isPresent();
+        }
+
+        private Optional<Field> firstSet(Field... candidates) {
+            return Arrays.stream(candidates).filter(this::isSet).findFirst();
+        }
+
+        /// A candidate is an unmet requirement when some [OrFields] group contains it
+        /// and none of that group's alternatives is set.
+        private Optional<Field> firstUnmetRequired(Field... candidates) {
+            return Arrays.stream(candidates)
+                         .filter(candidate -> requiredFields.stream()
+                                                            .anyMatch(group -> group.contains(candidate)
+                                                                    && group.getFields().stream().noneMatch(this::isSet)))
+                         .findFirst();
+        }
+
+        private String displayValue(Field field) {
+            String value = LatexToUnicodeAdapter.format(entry.getField(field).orElse(""))
+                                                .replaceAll("\\s+", " ")
+                                                .trim();
+            if (field == StandardField.PAGES) {
+                value = value.replace("--", "–");
+            }
+            if (value.length() > VALUE_DISPLAY_MAX_LENGTH) {
+                value = value.substring(0, VALUE_DISPLAY_MAX_LENGTH - 1) + "…";
+            }
+            return value;
+        }
+
+        private String displayPersons(Field field) {
+            String value = LatexToUnicodeAdapter.format(entry.getField(field).orElse(""));
+            String formatted = AuthorList.parse(value).getAsFirstLastNamesWithAnd();
+            return formatted.isBlank() ? displayValue(field) : formatted;
+        }
+
+        // endregion
+    }
+}

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/SemanticPreviewFlow.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/SemanticPreviewFlow.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.entryeditor;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import javafx.scene.Cursor;
@@ -8,12 +9,10 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 
-import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldTextMapper;
 
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 /// Renders the [CitationSegments] of an entry as a wrapping text flow — the visual
 /// part of the editable semantic preview in the [AllFieldsTab] (issue #12711,
@@ -29,7 +28,7 @@ public class SemanticPreviewFlow extends TextFlow {
 
     /// Renders the tokens; the segments of `editingField` (currently edited in place)
     /// get an extra highlight style.
-    public void render(CitationSegments segments, @Nullable Field editingField, Consumer<Field> onFieldClick) {
+    public void render(CitationSegments segments, Optional<Field> editingField, Consumer<Field> onFieldClick) {
         getChildren().clear();
         for (CitationSegments.Token token : segments.tokens()) {
             switch (token) {
@@ -44,7 +43,7 @@ public class SemanticPreviewFlow extends TextFlow {
                     if (style == CitationSegments.SegmentStyle.ITALIC) {
                         textNode.getStyleClass().add("semantic-preview-italic");
                     }
-                    if (field.equals(editingField)) {
+                    if (editingField.filter(field::equals).isPresent()) {
                         textNode.getStyleClass().add("semantic-preview-editing");
                     }
                     addClickableSegment(textNode, field, onFieldClick);
@@ -52,7 +51,7 @@ public class SemanticPreviewFlow extends TextFlow {
                 case CitationSegments.PlaceholderToken(Field field) -> {
                     Text textNode = new Text("{{" + FieldTextMapper.getDisplayName(field) + "}}");
                     textNode.getStyleClass().add("semantic-preview-placeholder");
-                    if (field.equals(editingField)) {
+                    if (editingField.filter(field::equals).isPresent()) {
                         textNode.getStyleClass().add("semantic-preview-editing");
                     }
                     addClickableSegment(textNode, field, onFieldClick);
@@ -63,8 +62,7 @@ public class SemanticPreviewFlow extends TextFlow {
 
     private void addClickableSegment(Text textNode, Field field, Consumer<Field> onFieldClick) {
         textNode.setCursor(Cursor.HAND);
-        Tooltip.install(textNode, new Tooltip(
-                Localization.lang("Edit") + ": " + FieldTextMapper.getDisplayName(field)));
+        Tooltip.install(textNode, new Tooltip(FieldTextMapper.getDisplayName(field)));
         textNode.setOnMouseClicked(event -> {
             if (event.getButton() == MouseButton.PRIMARY) {
                 onFieldClick.accept(field);

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/SemanticPreviewFlow.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/SemanticPreviewFlow.java
@@ -13,6 +13,7 @@ import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldTextMapper;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /// Renders the [CitationSegments] of an entry as a wrapping text flow — the visual
 /// part of the editable semantic preview in the [AllFieldsTab] (issue #12711,
@@ -26,7 +27,9 @@ public class SemanticPreviewFlow extends TextFlow {
         getStyleClass().add("semantic-preview-flow");
     }
 
-    public void render(CitationSegments segments, Consumer<Field> onFieldClick) {
+    /// Renders the tokens; the segments of `editingField` (currently edited in place)
+    /// get an extra highlight style.
+    public void render(CitationSegments segments, @Nullable Field editingField, Consumer<Field> onFieldClick) {
         getChildren().clear();
         for (CitationSegments.Token token : segments.tokens()) {
             switch (token) {
@@ -41,11 +44,17 @@ public class SemanticPreviewFlow extends TextFlow {
                     if (style == CitationSegments.SegmentStyle.ITALIC) {
                         textNode.getStyleClass().add("semantic-preview-italic");
                     }
+                    if (field.equals(editingField)) {
+                        textNode.getStyleClass().add("semantic-preview-editing");
+                    }
                     addClickableSegment(textNode, field, onFieldClick);
                 }
                 case CitationSegments.PlaceholderToken(Field field) -> {
                     Text textNode = new Text("{{" + FieldTextMapper.getDisplayName(field) + "}}");
                     textNode.getStyleClass().add("semantic-preview-placeholder");
+                    if (field.equals(editingField)) {
+                        textNode.getStyleClass().add("semantic-preview-editing");
+                    }
                     addClickableSegment(textNode, field, onFieldClick);
                 }
             }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/SemanticPreviewFlow.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/SemanticPreviewFlow.java
@@ -1,0 +1,66 @@
+package org.jabref.gui.entryeditor;
+
+import java.util.function.Consumer;
+
+import javafx.scene.Cursor;
+import javafx.scene.control.Tooltip;
+import javafx.scene.input.MouseButton;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldTextMapper;
+
+import org.jspecify.annotations.NullMarked;
+
+/// Renders the [CitationSegments] of an entry as a wrapping text flow — the visual
+/// part of the editable semantic preview in the [AllFieldsTab] (issue #12711,
+/// concept #2). Field values and `{{placeholders}}` are clickable segments (the
+/// click callback opens the field's editor); punctuation is inert text.
+// [impl->req~entry-editor.main-tab.semantic-preview~1]
+@NullMarked
+public class SemanticPreviewFlow extends TextFlow {
+
+    public SemanticPreviewFlow() {
+        getStyleClass().add("semantic-preview-flow");
+    }
+
+    public void render(CitationSegments segments, Consumer<Field> onFieldClick) {
+        getChildren().clear();
+        for (CitationSegments.Token token : segments.tokens()) {
+            switch (token) {
+                case CitationSegments.TextToken(String text) -> {
+                    Text textNode = new Text(text);
+                    textNode.getStyleClass().add("semantic-preview-text");
+                    getChildren().add(textNode);
+                }
+                case CitationSegments.FieldToken(Field field, String displayText, CitationSegments.SegmentStyle style) -> {
+                    Text textNode = new Text(displayText);
+                    textNode.getStyleClass().add("semantic-preview-value");
+                    if (style == CitationSegments.SegmentStyle.ITALIC) {
+                        textNode.getStyleClass().add("semantic-preview-italic");
+                    }
+                    addClickableSegment(textNode, field, onFieldClick);
+                }
+                case CitationSegments.PlaceholderToken(Field field) -> {
+                    Text textNode = new Text("{{" + FieldTextMapper.getDisplayName(field) + "}}");
+                    textNode.getStyleClass().add("semantic-preview-placeholder");
+                    addClickableSegment(textNode, field, onFieldClick);
+                }
+            }
+        }
+    }
+
+    private void addClickableSegment(Text textNode, Field field, Consumer<Field> onFieldClick) {
+        textNode.setCursor(Cursor.HAND);
+        Tooltip.install(textNode, new Tooltip(
+                Localization.lang("Edit") + ": " + FieldTextMapper.getDisplayName(field)));
+        textNode.setOnMouseClicked(event -> {
+            if (event.getButton() == MouseButton.PRIMARY) {
+                onFieldClick.accept(field);
+            }
+        });
+        getChildren().add(textNode);
+    }
+}

--- a/jabgui/src/main/java/org/jabref/gui/keyboard/WalkthroughKeyBindings.java
+++ b/jabgui/src/main/java/org/jabref/gui/keyboard/WalkthroughKeyBindings.java
@@ -3,7 +3,6 @@ package org.jabref.gui.keyboard;
 import javafx.scene.input.KeyEvent;
 
 import org.jabref.gui.StateManager;
-import org.jabref.gui.walkthrough.Walkthrough;
 
 public class WalkthroughKeyBindings {
 
@@ -15,8 +14,13 @@ public class WalkthroughKeyBindings {
     public static void call(KeyEvent event, StateManager stateManager, KeyBindingRepository keyBindingRepository) {
         keyBindingRepository.mapToKeyBinding(event).ifPresent(binding -> {
             if (binding == KeyBinding.CLOSE) { // NOTE: CLOSE is using Esc key. Therefore, we didn't introduce a new key binding entry since this would lead to conflicts with other key bindings.
-                stateManager.getActiveWalkthrough().ifPresent(Walkthrough::showQuitConfirmationAndQuit);
-                event.consume();
+                // Only consume the event when a walkthrough is actually active — this filter
+                // sits on the main scene, so consuming unconditionally would swallow Esc for
+                // the entire application (dialogs, entry editor, ...).
+                stateManager.getActiveWalkthrough().ifPresent(walkthrough -> {
+                    walkthrough.showQuitConfirmationAndQuit();
+                    event.consume();
+                });
             }
         });
     }

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1167,6 +1167,40 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-padding: 4 0 0 0;
 }
 
+/* Editable semantic preview at the top of the "Main" tab (issue #12711, concept #2) */
+#entryEditor .semantic-preview-flow {
+    -fx-padding: 6 4 10 4;
+    -fx-line-spacing: 3;
+    -fx-font-size: 1.1em;
+}
+
+#entryEditor .semantic-preview-flow .semantic-preview-text {
+    -fx-fill: -fx-text-base-color;
+}
+
+#entryEditor .semantic-preview-flow .semantic-preview-value {
+    -fx-fill: -fx-text-base-color;
+}
+
+#entryEditor .semantic-preview-flow .semantic-preview-value:hover {
+    -fx-underline: true;
+    -fx-fill: -jr-theme-text;
+}
+
+#entryEditor .semantic-preview-flow .semantic-preview-italic {
+    -fx-font-style: italic;
+}
+
+#entryEditor .semantic-preview-flow .semantic-preview-placeholder {
+    -fx-fill: -fx-mid-text-color;
+    -fx-font-style: italic;
+}
+
+#entryEditor .semantic-preview-flow .semantic-preview-placeholder:hover {
+    -fx-underline: true;
+    -fx-fill: -jr-theme-text;
+}
+
 #entryEditor Text {
     -fx-text-fill: -fx-text-base-color;
     -fx-fill: -fx-text-base-color;

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1168,6 +1168,50 @@ We want to have a look that matches our icons in the tool-bar */
 }
 
 /* Editable semantic preview at the top of the "Main" tab (issue #12711, concept #2) */
+#entryEditor .semantic-preview-header {
+    -fx-spacing: 8;
+    -fx-padding: 4 4 0 4;
+}
+
+#entryEditor .semantic-preview-header .semantic-preview-entry-type {
+    -fx-text-fill: -fx-mid-text-color;
+    -fx-font-family: monospace;
+}
+
+#entryEditor .semantic-preview-header .semantic-preview-entry-type:hover {
+    -fx-text-fill: -jr-theme;
+    -fx-underline: true;
+}
+
+#entryEditor .semantic-preview-header .semantic-preview-header-separator {
+    -fx-text-fill: -fx-mid-text-color;
+}
+
+#entryEditor .semantic-preview-header .semantic-preview-citation-key {
+    -fx-font-family: monospace;
+    -fx-font-weight: bold;
+}
+
+#entryEditor .semantic-preview-header .semantic-preview-citation-key:hover {
+    -fx-text-fill: -jr-theme;
+    -fx-underline: true;
+}
+
+#entryEditor .semantic-preview-header .semantic-preview-citation-key-missing {
+    -fx-text-fill: derive(-jr-theme, 25%);
+    -fx-font-style: italic;
+}
+
+#entryEditor .semantic-preview-header .semantic-preview-citation-key-missing:hover {
+    -fx-text-fill: -jr-theme;
+    -fx-underline: true;
+}
+
+#entryEditor .semantic-preview-header .semantic-preview-editing {
+    -fx-text-fill: -jr-theme;
+    -fx-underline: true;
+}
+
 #entryEditor .semantic-preview-flow {
     -fx-padding: 6 4 10 4;
     -fx-line-spacing: 3;

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1184,7 +1184,7 @@ We want to have a look that matches our icons in the tool-bar */
 
 #entryEditor .semantic-preview-flow .semantic-preview-value:hover {
     -fx-underline: true;
-    -fx-fill: -jr-theme-text;
+    -fx-fill: -jr-theme;
 }
 
 #entryEditor .semantic-preview-flow .semantic-preview-italic {
@@ -1192,13 +1192,29 @@ We want to have a look that matches our icons in the tool-bar */
 }
 
 #entryEditor .semantic-preview-flow .semantic-preview-placeholder {
-    -fx-fill: -fx-mid-text-color;
+    -fx-fill: derive(-jr-theme, 25%);
     -fx-font-style: italic;
 }
 
 #entryEditor .semantic-preview-flow .semantic-preview-placeholder:hover {
     -fx-underline: true;
-    -fx-fill: -jr-theme-text;
+    -fx-fill: -jr-theme;
+}
+
+#entryEditor .semantic-preview-flow .semantic-preview-editing {
+    -fx-fill: -jr-theme;
+    -fx-underline: true;
+    -fx-font-weight: bold;
+}
+
+/* Overlay row hosting the in-place editor beneath the preview flow */
+#entryEditor .semantic-preview-editor-row {
+    -fx-spacing: 8;
+    -fx-padding: 2 4 10 4;
+}
+
+#entryEditor .semantic-preview-editor-label {
+    -fx-font-weight: bold;
 }
 
 #entryEditor Text {

--- a/jabgui/src/test/java/org/jabref/gui/entryeditor/CitationSegmentsTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/entryeditor/CitationSegmentsTest.java
@@ -1,0 +1,289 @@
+package org.jabref.gui.entryeditor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.jabref.model.database.BibDatabaseMode;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryType;
+import org.jabref.model.entry.BibEntryTypeBuilder;
+import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.entry.types.UnknownEntryType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CitationSegmentsTest {
+
+    private final BibEntryTypesManager entryTypesManager = new BibEntryTypesManager();
+
+    private CitationSegments segmentsOf(BibEntry entry, BibDatabaseMode mode) {
+        return CitationSegments.of(entry, entryTypesManager.enrich(entry.getType(), mode));
+    }
+
+    /// Flattens the token list to a plain string; placeholders render as {{name}}.
+    private static String render(CitationSegments segments) {
+        return segments.tokens().stream()
+                       .map(token -> switch (token) {
+                           case CitationSegments.TextToken(String text) ->
+                                   text;
+                           case CitationSegments.FieldToken(Field _, String displayText, CitationSegments.SegmentStyle _) ->
+                                   displayText;
+                           case CitationSegments.PlaceholderToken(Field field) ->
+                                   "{{" + field.getName() + "}}";
+                       })
+                       .collect(Collectors.joining());
+    }
+
+    private static Optional<CitationSegments.FieldToken> fieldTokenOf(CitationSegments segments, Field field) {
+        return segments.tokens().stream()
+                       .filter(token -> token instanceof CitationSegments.FieldToken(Field tokenField, String _, CitationSegments.SegmentStyle _)
+                               && tokenField == field)
+                       .map(CitationSegments.FieldToken.class::cast)
+                       .findFirst();
+    }
+
+    @Test
+    void completeArticleRendersCitationLike() {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Doe, John and Smith, Jane")
+                .withField(StandardField.TITLE, "Great Results")
+                .withField(StandardField.JOURNAL, "Journal of Tests")
+                .withField(StandardField.VOLUME, "12")
+                .withField(StandardField.NUMBER, "3")
+                .withField(StandardField.PAGES, "45--67")
+                .withField(StandardField.YEAR, "2020");
+
+        assertEquals("John Doe and Jane Smith. Great Results. Journal of Tests, 12(3):45–67, 2020.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBTEX)));
+    }
+
+    @Test
+    void emptyArticleRendersRequiredPlaceholders() {
+        BibEntry entry = new BibEntry(StandardEntryType.Article);
+
+        assertEquals("{{author}}. {{title}}. {{journal}}, {{year}}.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBTEX)));
+    }
+
+    @Test
+    void emptyBiblatexArticleUsesJournaltitleAndDate() {
+        BibEntry entry = new BibEntry(StandardEntryType.Article);
+
+        assertEquals("{{author}}. {{title}}. {{journaltitle}}, {{date}}.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBLATEX)));
+    }
+
+    @Test
+    void coveredFieldsListRenderedAndPlaceholderFields() {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Doe, John")
+                .withField(StandardField.YEAR, "2020");
+
+        assertEquals(List.of(StandardField.AUTHOR, StandardField.TITLE, StandardField.JOURNAL, StandardField.YEAR),
+                List.copyOf(segmentsOf(entry, BibDatabaseMode.BIBTEX).coveredFields()));
+    }
+
+    @Test
+    void editorOnlyBookIsMarkedAsEdited() {
+        BibEntry entry = new BibEntry(StandardEntryType.Book)
+                .withField(StandardField.EDITOR, "Doe, John")
+                .withField(StandardField.TITLE, "Collected Works")
+                .withField(StandardField.PUBLISHER, "ACME")
+                .withField(StandardField.YEAR, "2020");
+
+        assertEquals("John Doe (Eds.). Collected Works. ACME, 2020.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBTEX)));
+    }
+
+    @Test
+    void bookTitleIsItalicArticleTitleIsPlain() {
+        BibEntry book = new BibEntry(StandardEntryType.Book)
+                .withField(StandardField.TITLE, "Collected Works");
+        BibEntry article = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.TITLE, "Great Results")
+                .withField(StandardField.JOURNAL, "Journal of Tests");
+
+        CitationSegments bookSegments = segmentsOf(book, BibDatabaseMode.BIBTEX);
+        CitationSegments articleSegments = segmentsOf(article, BibDatabaseMode.BIBTEX);
+
+        assertEquals(CitationSegments.SegmentStyle.ITALIC,
+                fieldTokenOf(bookSegments, StandardField.TITLE).orElseThrow().style());
+        assertEquals(CitationSegments.SegmentStyle.PLAIN,
+                fieldTokenOf(articleSegments, StandardField.TITLE).orElseThrow().style());
+        assertEquals(CitationSegments.SegmentStyle.ITALIC,
+                fieldTokenOf(articleSegments, StandardField.JOURNAL).orElseThrow().style());
+    }
+
+    @Test
+    void volumeWithoutNumberOmitsParentheses() {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Doe, John")
+                .withField(StandardField.TITLE, "Great Results")
+                .withField(StandardField.JOURNAL, "Journal of Tests")
+                .withField(StandardField.VOLUME, "12")
+                .withField(StandardField.PAGES, "45")
+                .withField(StandardField.YEAR, "2020");
+
+        assertEquals("John Doe. Great Results. Journal of Tests, 12:45, 2020.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBTEX)));
+    }
+
+    @Test
+    void pagesWithoutVolumeAreLabeled() {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Doe, John")
+                .withField(StandardField.TITLE, "Great Results")
+                .withField(StandardField.JOURNAL, "Journal of Tests")
+                .withField(StandardField.PAGES, "45--67")
+                .withField(StandardField.YEAR, "2020");
+
+        assertEquals("John Doe. Great Results. Journal of Tests, pages 45–67, 2020.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBTEX)));
+    }
+
+    @Test
+    void numberWithoutVolumeIsLabeled() {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Doe, John")
+                .withField(StandardField.TITLE, "Great Results")
+                .withField(StandardField.JOURNAL, "Journal of Tests")
+                .withField(StandardField.NUMBER, "3")
+                .withField(StandardField.YEAR, "2020");
+
+        assertEquals("John Doe. Great Results. Journal of Tests, number 3, 2020.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBTEX)));
+    }
+
+    @Test
+    void inProceedingsRendersBooktitleWithInPrefix() {
+        BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
+                .withField(StandardField.AUTHOR, "Doe, John")
+                .withField(StandardField.TITLE, "Great Results")
+                .withField(StandardField.BOOKTITLE, "Proceedings of Testing")
+                .withField(StandardField.PAGES, "1--2")
+                .withField(StandardField.YEAR, "2020");
+
+        assertEquals("John Doe. Great Results. In Proceedings of Testing, pages 1–2, 2020.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBTEX)));
+    }
+
+    @Test
+    void missingBooktitlePlaceholderKeepsInPrefix() {
+        BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
+                .withField(StandardField.AUTHOR, "Doe, John")
+                .withField(StandardField.TITLE, "Great Results")
+                .withField(StandardField.YEAR, "2020");
+
+        assertEquals("John Doe. Great Results. In {{booktitle}}, 2020.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBTEX)));
+    }
+
+    @Test
+    void phdThesisRendersSchool() {
+        BibEntry entry = new BibEntry(StandardEntryType.PhdThesis)
+                .withField(StandardField.AUTHOR, "Doe, John")
+                .withField(StandardField.TITLE, "Deep Insights")
+                .withField(StandardField.SCHOOL, "MIT")
+                .withField(StandardField.YEAR, "2020");
+
+        assertEquals("John Doe. Deep Insights. MIT, 2020.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBTEX)));
+    }
+
+    @Test
+    void emptyBiblatexThesisRendersTypeInstitutionAndDatePlaceholders() {
+        BibEntry entry = new BibEntry(StandardEntryType.Thesis);
+
+        assertEquals("{{author}}. {{title}}. {{type}}, {{institution}}, {{date}}.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBLATEX)));
+    }
+
+    @Test
+    void dateAliasIsUsedWhenYearUnset() {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Doe, John")
+                .withField(StandardField.TITLE, "Great Results")
+                .withField(StandardField.JOURNALTITLE, "Journal of Tests")
+                .withField(StandardField.DATE, "2020-07");
+
+        assertEquals("John Doe. Great Results. Journal of Tests, 2020-07.",
+                render(segmentsOf(entry, BibDatabaseMode.BIBLATEX)));
+    }
+
+    @Test
+    void latexIsConvertedForDisplay() {
+        BibEntry entry = new BibEntry(StandardEntryType.Book)
+                .withField(StandardField.TITLE, "Gr{\\\"o}bner Bases");
+
+        assertEquals("Gröbner Bases",
+                fieldTokenOf(segmentsOf(entry, BibDatabaseMode.BIBTEX), StandardField.TITLE)
+                        .orElseThrow().displayText());
+    }
+
+    @Test
+    void whitespaceIsCollapsedForDisplay() {
+        BibEntry entry = new BibEntry(StandardEntryType.Book)
+                .withField(StandardField.TITLE, "Collected\n   Works");
+
+        assertEquals("Collected Works",
+                fieldTokenOf(segmentsOf(entry, BibDatabaseMode.BIBTEX), StandardField.TITLE)
+                        .orElseThrow().displayText());
+    }
+
+    @Test
+    void longValuesAreTruncatedWithEllipsis() {
+        BibEntry entry = new BibEntry(StandardEntryType.Book)
+                .withField(StandardField.TITLE, "a".repeat(300));
+
+        String displayText = fieldTokenOf(segmentsOf(entry, BibDatabaseMode.BIBTEX), StandardField.TITLE)
+                .orElseThrow().displayText();
+
+        assertEquals(CitationSegments.VALUE_DISPLAY_MAX_LENGTH, displayText.length());
+        assertTrue(displayText.endsWith("…"));
+    }
+
+    @Test
+    void requiredFieldOutsideVocabularyBecomesTrailingPlaceholder() {
+        BibEntryType gadgetType = new BibEntryTypeBuilder()
+                .withType(new UnknownEntryType("gadget"))
+                .withRequiredFields(StandardField.SERIES)
+                .build();
+        BibEntry entry = new BibEntry(new UnknownEntryType("gadget"))
+                .withField(StandardField.TITLE, "Great Results");
+
+        CitationSegments segments = CitationSegments.of(entry, Optional.of(gadgetType));
+
+        assertEquals("Great Results. {{series}}.", render(segments));
+        assertEquals(List.of(StandardField.TITLE, StandardField.SERIES),
+                List.copyOf(segments.coveredFields()));
+    }
+
+    @Test
+    void emptyMiscRendersNothing() {
+        BibEntry entry = new BibEntry(StandardEntryType.Misc);
+
+        CitationSegments segments = segmentsOf(entry, BibDatabaseMode.BIBTEX);
+
+        assertEquals(List.of(), segments.tokens());
+        assertEquals(List.of(), List.copyOf(segments.coveredFields()));
+    }
+
+    @Test
+    void unknownTypeWithoutDefinitionFallsBack() {
+        BibEntry entry = new BibEntry(new UnknownEntryType("whatever"))
+                .withField(StandardField.AUTHOR, "Doe, John")
+                .withField(StandardField.TITLE, "Great Results")
+                .withField(StandardField.HOWPUBLISHED, "Self-published")
+                .withField(StandardField.YEAR, "2020");
+
+        assertEquals("John Doe. Great Results. Self-published, 2020.",
+                render(CitationSegments.of(entry, Optional.empty())));
+    }
+}


### PR DESCRIPTION
### Related issues and pull requests

Refs https://github.com/JabRef/jabref/issues/12711 (concept #2 — intentionally not "Closes": this is an internal design-discussion PR, like #731 was for concept #1, which is merged upstream as JabRef/jabref#16166).

Refs https://github.com/JabRef/jabref/issues/6856

### PR Description

The "Main" tab of the entry editor now renders the entry as an **editable semantic preview**: a citation-like text driven by per-entry-type templates, where every field value — and every `{{placeholder}}` for a missing required field — is clicked to edit it **in place**. A `@type · citationkey` header line changes the entry type (menu) and the citation key (editor incl. Generate button). Fields not represented in the preview keep their editor rows and collapsible sections below; the preview takes precedence, so **a field never appears twice** on the tab (goal: reduce cognitive load).

How editing works: clicking a segment opens the field's regular editor in an overlay row directly beneath the preview with the segment highlighted (a literal inline swap inside the TextFlow was rejected — field editors are compound HBox controls that would wreck the line layout). Typing writes through live (preview, main table, and preview panel follow each keystroke); <kbd>Enter</kbd>/focus-out closes and keeps, <kbd>Esc</kbd> restores the pre-edit value; jump-to-field routes preview-covered fields to the overlay.

Bonus bugfix in its own commit (candidate for a separate upstream PR): `WalkthroughKeyBindings` consumed **every <kbd>Esc</kbd> in the main scene even without an active walkthrough** (scene-level filter, `event.consume()` outside the `ifPresent`), so no control in the main window ever received <kbd>Esc</kbd>.

Open questions for the design discussion (details + full verification log in `PLAN.md` in this branch):

1. Keep the classic side-by-side CSL preview panel on the Main tab (currently kept) — or is a double preview too much?
2. Fixed hand-rolled templates (current) vs deriving the preview from the user's CSL style (hard: CSL output is opaque HTML)?
3. Known quirk: a required-outside-vocabulary field (e.g. biblatex `url` for `@online`) is a trailing placeholder while unset but moves to its section once set.
4. <kbd>Esc</kbd>-restore bypasses the undo manager. (Side observation: Edit > Undo currently stays greyed for *all* entry editor edits — also for plain rows on `main`; pre-existing.)

**Analogies**: Like honey, the semantic preview is sweetest when everything sticks together in one place — no field appears twice. Like chocolate, it comes in clearly separated pieces: each segment breaks off cleanly into its own editor and snaps back in. And like the moon, the preview only ever shows one face of the entry — the full data set stays in orbit right below it.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

```bash
git submodule update --init jablib/src/main/resources/csl-styles jablib/src/main/resources/csl-locales
./gradlew :jabgui:run
```

Open any entry → "Main" tab. Then:

1. Click the title or author text in the preview line, type — watch the preview, the main table, and the preview panel follow live; press <kbd>Enter</kbd> to close.
2. Click a `{{placeholder}}` (e.g. `{{Year}}` on an entry without a year), type a value — the placeholder becomes a value.
3. Click a value, change it, press <kbd>Esc</kbd> — the old value comes back.
4. Click the citation key in the `@type · key` header — the citation key editor (with Generate) opens; click the `@type` chip to change the entry type and watch the preview re-template (e.g. `{{Journal}}` → `{{Publisher}}`).
5. <kbd>Ctrl</kbd>+<kbd>J</kbd> (jump to field) → "title" opens the in-place editor.

Screenshots:

| Placeholders + header | In-place editing (live) |
|---|---|
| ![placeholders](https://raw.githubusercontent.com/JabRef/jabref-koppor/koppor-images-in-place-edit/main-tab-placeholders-header.png) | ![in-place editing](https://raw.githubusercontent.com/JabRef/jabref-koppor/koppor-images-in-place-edit/main-tab-inplace-editing-live.png) |

| Citation key editor | After type change to `@book` |
|---|---|
| ![citation key editor](https://raw.githubusercontent.com/JabRef/jabref-koppor/koppor-images-in-place-edit/main-tab-citation-key-editor.png) | ![type changed](https://raw.githubusercontent.com/JabRef/jabref-koppor/koppor-images-in-place-edit/main-tab-type-changed-book.png) |

### AI usage

Claude Code (model claude-opus-4-8), driven interactively by @koppor; all changes live-verified in the running application on a real display during development.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

#### 1. Code self-review

##### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [x] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
  - `CitationSegments` and `SemanticPreviewFlow` are both `@NullMarked`.
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [x] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.
  - `StringUtil::isNotBlank` used in `Optional` filters.

#### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
  - No exception handling added at all.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.
  - No logging added.

#### Style and idioms

- [x] New `BibEntry` objects built with withers (`withField`, not `setField`).
  - In `CitationSegmentsTest`; production code edits existing entries via the two-way editor bindings (and `setField`/`clearField` only for the Esc restore, matching existing editor behavior).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
  - Records, sealed interface, record deconstruction patterns in `switch`, `SequencedSet`.
- [x] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
  - `CitationSegments.WHITESPACE`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
  - No background work added.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

#### User-facing text

- [x] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
  - Only existing keys used ("Change entry type"); segment tooltips show the localized field display name via `FieldTextMapper`.
- [x] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.
  - No parameterized user-facing strings added.

#### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).
  - No `text/html` output; the preview renders JavaFX `Text` nodes, which do not interpret markup.

#### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
  - No model/logic changes; the new GUI-side logic is covered by `CitationSegmentsTest` (20 tests: templates, placeholders, punctuation suppression, alias slots, coveredFields, LaTeX→Unicode, truncation, trailing placeholders).
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.

#### 2. Verification commands

- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
  - Ran `./gradlew :jabgui:check` for the changed module (green); `jablib` sources untouched, its `LocalizationConsistencyTest` ran separately and is green.
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
  - `:jabgui:checkstyleMain` and `:jabgui:checkstyleTest` green; `checkstyleJmh` does not exist for `jabgui` (no JMH sources).
- [x] `./gradlew modernizer`.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [x] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
  - 0 errors on the changed files (`CHANGELOG.md`, `docs/requirements/entry-editor.md`, `PLAN.md`).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.
  - Formatting clean.

#### 3. Documentation

- [x] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number.
  - Added entry for the editable semantic preview; Fixed entry for the app-wide Esc bug.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
  - JabRef/jabref#12711 is the issue both entry editor concepts implement; the Esc fix references JabRef/jabref#13595 (the PR that introduced the walkthrough key handler).
- [x] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
  - `docs/requirements/entry-editor.md`: `semantic-preview`, `in-place-edit`, `no-duplication` added, `single-list` reworded; `./gradlew traceRequirements` green.
- [x] Developer documentation under `docs/` updated if behavior or architecture changed.

#### 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed.
  - No `TODO` placeholder used (real issue references).

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
